### PR TITLE
Add Claude Code Growth OS starter (four-function GTM kit)

### DIFF
--- a/.claude/commands/demo-briefing.md
+++ b/.claude/commands/demo-briefing.md
@@ -1,0 +1,18 @@
+---
+description: Run the full morning ritual against the fictional demo/ data — a safe way to see it work, and a safe thing to present from.
+---
+
+# Demo Briefing
+
+Run the morning ritual against the **fictional** sample data in `demo/`. Nothing here is real — these are made-up companies.
+
+In order:
+
+1. **Priorities.** Read `demo/priorities.md` and list what's open.
+2. **Pipeline.** Read `demo/pipeline.md`. Flag any deal with no activity in 7+ days or no next step — call out the top-tier ones first.
+3. **Commitments → tasks.** Read every note in `demo/meetings/`. Pull out each commitment "you" made and turn it into a task with an owner and a due date.
+4. **Field intel → marketing.** Read `demo/feedback-log.md` and surface the `MARKETING-ACTION` lines — the recurring objections and missing proof points sales should hand to marketing. This is the sales→marketing loop.
+5. **Retention signal → product.** From the same `demo/feedback-log.md`, surface the `RETENTION-RISK` (and `EXPANSION-SIGNAL`) lines — accounts in onboarding or production whose adoption is slipping or who are ready to grow, routed to product/CS. This is the post-sale→product loop — the half most teams never wire.
+6. **Today's top three.** Propose exactly three priorities for today, each with a one-line reason. At least one must advance a deal; at least one must protect or expand an existing customer.
+
+Keep it tight. Lead with the top three. No preamble.

--- a/.claude/commands/end-of-day.md
+++ b/.claude/commands/end-of-day.md
@@ -1,0 +1,17 @@
+---
+description: Close the day — log what happened, tee up tomorrow.
+---
+
+# End of Day
+
+Close out the day:
+
+1. Ask me what got done today (or infer it from `git log` since this morning) — across both sides of the bowtie: deals worked *and* post-sale touches (onboarding steps, adoption nudges, renewal/expansion moves, signals routed to product).
+2. Append a dated entry to `ops/daily-log.md` (newest at the top): shipped, slipped, one thing learned. Log post-sale work alongside deals — a renewal call or an adoption fix counts the same as a deal advanced.
+3. Draft tomorrow's top three into `ops/priorities.md`.
+4. Confirm what you wrote. Keep it tight.
+
+## Depth
+- quick: log one line (shipped / slipped) and tomorrow's top item.
+- standard: the full close above.
+- deep: add what to stop doing and a 7-day pattern note.

--- a/.claude/commands/midday-checkin.md
+++ b/.claude/commands/midday-checkin.md
@@ -1,0 +1,18 @@
+---
+description: Mid-day reset — what's done, what's slipping, what to protect this afternoon.
+---
+
+# Midday Check-in
+
+A quick reset. In order:
+
+1. Read `ops/priorities.md` and today's top three (from this morning's `/morning-briefing`, or the latest `ops/daily-log.md` entry).
+2. Mark what's done. Flag anything at risk of not happening today.
+3. Name the one thing that must happen this afternoon — and protect time for it. (It can be a deal or a post-sale move — whichever is most at risk of slipping.)
+
+Keep it to a few lines. No recap of things already finished.
+
+## Depth
+- quick: the one thing that must happen this afternoon.
+- standard: the full reset above.
+- deep: re-rank the afternoon against the week's priorities, not just today's.

--- a/.claude/commands/morning-briefing.md
+++ b/.claude/commands/morning-briefing.md
@@ -1,0 +1,21 @@
+---
+description: Recap yesterday, surface priorities, set today's top three.
+---
+
+# Morning Briefing
+
+Run my morning ritual, in order:
+
+1. **Priorities.** Read `ops/priorities.md` and list what's still open.
+2. **Yesterday.** Read the most recent entry in `ops/daily-log.md`. Summarize what got done and what's still hanging.
+3. **Field intel → marketing.** Scan the latest `ops/daily-log.md` entry (and any fresh meeting notes) for recurring objections, competitor mentions, missing proof, or win/loss reasons, and surface them as `MARKETING-ACTION` lines so marketing can act — this is what the `marketing-feedback` skill does. Skip if there's nothing new.
+4. **Post-sale read.** Scan `ops/customers.md` for anything that needs attention today: renewals inside 60 days, accounts at 🔴/🟡 (usage down, champion quiet, single-threaded), and adoption stalls (a workflow never turned on). Then surface the top one or two open items in `ops/roadmap-signals.md`. Skip a line if the file is empty.
+5. **Today's top three.** Propose exactly three priorities for today, each with a one-line reason. At least one should move something forward, not just maintain it; lean toward covering both sides of the bowtie when both have live work.
+6. **Offer.** Ask if I want to append today's plan to `ops/daily-log.md`.
+
+Keep it short. Lead with the top three. No preamble.
+
+## Depth
+- quick: just today's top three.
+- standard: the full ritual above.
+- deep: add a week-over-week read of the log and flag anything slipping.

--- a/.claude/commands/weekly-review.md
+++ b/.claude/commands/weekly-review.md
@@ -1,0 +1,33 @@
+---
+description: Weekly review — read the week's logs, surface patterns, set next week's one priority.
+---
+
+# Weekly Review
+
+Run an honest weekly review across the whole motion — both sides of the bowtie.
+
+**Left side (demand → close):**
+
+1. Read the last seven entries in `ops/daily-log.md`.
+2. Summarize the week: what shipped, what stalled, any pattern worth naming.
+3. Clear the loop: surface any open `MARKETING-ACTION` lines in the feedback log that haven't been acted on.
+
+**Right side (post-sale — read `ops/customers.md`):**
+
+4. **Renewals due** in the next 30 / 60 / 90 days. Flag any inside 60 days — that's when the renewal motion starts (not day 85).
+5. **Accounts at risk.** List anything at 🔴/🟡 — usage down, champion quiet, single-threaded — and the next step for each.
+6. **Adoption stalls.** Accounts stuck between onboarding and live (a workflow never turned on, a setup step blocking them).
+7. **Expansion candidates.** Healthy accounts ready to grow — hand to sales with the CS context.
+8. **Top roadmap signals.** The highest-priority items in `ops/roadmap-signals.md` — what product should hear, and anything shipped that still needs its buyer-facing line.
+
+**Then:**
+
+9. Pick next week's single most important priority and write it to the top of `ops/priorities.md`.
+10. Name one thing to stop doing.
+
+Lead with the summary. Don't pad it. If `ops/customers.md` or `ops/roadmap-signals.md` is empty, say so and skip that section.
+
+## Depth
+- quick: the week's three-line summary, renewals/risks inside 60 days, and next week's one priority.
+- standard: the full review above, both sides.
+- deep: add month-over-month patterns, a stop-doing list, and an NRR-direction read (are accounts net expanding or net leaking?).

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# git pre-commit guard — block commits that contain likely secrets.
+# This is a *git* hook, not a Claude Code hook. Install it once:
+#
+#   ln -s ../../.claude/hooks/pre-commit-guard.sh .git/hooks/pre-commit
+#   chmod +x .claude/hooks/pre-commit-guard.sh
+#
+# Pure bash + grep. Scans only what's staged.
+
+staged="$(git diff --cached --name-only --diff-filter=ACM || true)"
+[ -z "$staged" ] && exit 0
+
+patterns='(AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|sk-[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]+|ghp_[A-Za-z0-9]{36}|(password|api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]+)'
+
+hits="$(git diff --cached -U0 | grep -nEi "$patterns" || true)"
+if [ -n "$hits" ]; then
+  echo "Commit blocked — possible secret in staged changes:" >&2
+  echo "$hits" | head -5 >&2
+  echo "Remove it (and rotate it if it ever touched disk), then commit again." >&2
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreCompact — re-inject durable state so a long session doesn't lose the thread.
+# The trick: your state lives in plain-text files, so compaction can't erase it.
+# This hook simply re-surfaces it. Pure bash, no dependencies.
+
+DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+echo "## Re-injected after compaction — $(date '+%Y-%m-%d %H:%M')"
+echo
+
+if [ -f "$DIR/ops/priorities.md" ]; then
+  echo "### Priorities"
+  cat "$DIR/ops/priorities.md"
+  echo
+fi
+
+if [ -f "$DIR/ops/daily-log.md" ]; then
+  echo "### Latest log entry"
+  awk '/^## /{c++} c==1{print} c==2{exit}' "$DIR/ops/daily-log.md"
+fi

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse(Edit|Write) — block the agent from writing to sensitive files.
+# Reads the hook payload with python3 (standard). Exit 2 blocks the tool call.
+
+payload="$(cat)"
+path="$(printf '%s' "$payload" | python3 -c 'import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_input", {}).get("file_path", ""))
+except Exception:
+    print("")' 2>/dev/null || true)"
+
+case "$path" in
+  *.env|*.env.*|*.pem|*.key|*.p12|*.pfx|*id_rsa*|*secret*|*credentials*|*.claude/settings.local.json)
+    echo "Blocked: '$path' looks sensitive. Edit it yourself, outside the agent." >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart — surface your priorities the moment a session opens.
+# Pure bash: no API keys, no MCP, runs anywhere. Edit ops/priorities.md to
+# change what shows up here.
+
+DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+echo "## Session start — $(date '+%Y-%m-%d %H:%M')"
+echo
+if [ -f "$DIR/ops/priorities.md" ]; then
+  cat "$DIR/ops/priorities.md"
+else
+  echo "No ops/priorities.md yet — run /morning-briefing to start the day."
+fi
+echo
+echo "Rituals: /morning-briefing · /midday-checkin · /end-of-day · /weekly-review"
+echo "New here? Run /demo-briefing to see it work on sample data."

--- a/.claude/hooks/stop-reminder.sh
+++ b/.claude/hooks/stop-reminder.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop — a gentle nudge to log the day. Stays quiet once you've logged today,
+# so it isn't noisy. Prints to stderr; never blocks. Pure bash.
+
+DIR="${CLAUDE_PROJECT_DIR:-.}"
+LOG="$DIR/ops/daily-log.md"
+TODAY="$(date '+%Y-%m-%d')"
+
+if [ -f "$LOG" ] && grep -q "## $TODAY" "$LOG"; then
+  exit 0
+fi
+echo "No log entry for $TODAY yet — run /end-of-day before you wrap up." >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Edit",
+      "Write",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(ls *)",
+      "Bash(date*)"
+    ],
+    "deny": [
+      "Read(.env*)",
+      "Edit(.env*)",
+      "Write(.env*)",
+      "Read(.claude/settings.local.json)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.sh" }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.sh" }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stop-reminder.sh" }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Local, machine-specific, or secret config — never commit
+.claude/settings.local.json
+.mcp.json
+.env
+.env.*
+
+# OS / editor noise
+.DS_Store
+*.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Claude Code Growth OS — Project Config
+
+This project uses Claude Code as a go-to-market operating environment — marketing, sales, product, and retention run as one motion, not four silos. The kit spans all four functions across both sides of the bowtie: acquisition on the left, and the post-sale half (onboarding, adoption, renewal, expansion) on the right. Plain-text playbooks in `ops/`, rituals as commands in `.claude/commands/`, go-to-market skills in `skills/`. The handoffs that connect the four functions — H1–H6 plus the loop close — are mapped in `docs/operating-model.md`.
+
+## Conventions
+
+- **Markdown is the source of truth.** Operating playbooks live in `ops/` as plain markdown. Edit them like docs; commit them like code.
+- **Both sides of the bowtie have a surface.** The left side is `ops/pipeline.md` (deals); the right side is `ops/customers.md` (the post-sale account book) and `ops/roadmap-signals.md` (product's triage queue). The renewal motion starts at day 60, not day 85.
+- **Rituals are commands.** A recurring task — a morning briefing, an end-of-day wrap-up — is a slash command in `.claude/commands/`. Invoke it by name.
+- **One ritual at a time.** Don't port your whole working life on day one. Pick the task you dread most, make it a command, run it daily for a week, then add the next.
+- **Commit often.** Your ops get a history. `git log ops/` is your audit trail.
+
+## Hooks
+
+Guardrails run on events, not memory (`.claude/hooks/`):
+
+- **SessionStart** surfaces `ops/priorities.md`.
+- **PreCompact** re-injects priorities + the latest log entry so long sessions don't lose the thread.
+- **PreToolUse(Edit|Write)** blocks writes to secrets, keys, and `.env`.
+- **Stop** nudges you to `/end-of-day` until today is logged.
+- A **git pre-commit guard** (`pre-commit-guard.sh`, install once) blocks commits containing likely secrets.
+
+All pure bash (one uses `python3` to read a payload). No API keys, no MCP required. The full thinking is in `docs/methodology.md`.
+
+## Extending with tools
+
+Add MCP servers (calendar, notes, issue tracker, CRM) via a local `.mcp.json`, then let your commands reach them. Keep machine-local config and secrets in `.claude/settings.local.json` (gitignored) — never commit them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+This is a starter — a clean, generic scaffold people fork and fill. Contributions that keep it that way are welcome.
+
+## Good contributions
+
+- **New hooks** — generic guardrails or automations (a useful PreToolUse check, a smarter session-start). Pure bash where possible; `python3` is fine where you need to parse a payload. No other dependencies.
+- **New ritual commands** — a daily/weekly ritual that generalizes beyond one job.
+- **New skill templates** — a repeatable unit of work with a specific trigger `description`.
+- **Docs and examples** — clearer quickstart, a worked example for a different kind of work (research, support, content).
+
+## The one rule
+
+**Keep it generic. No real data, ever.** No real company names, playbooks, pricing, credentials, or personal data — in code, commits, or examples. The `demo/` folder is fictional and must stay that way. If a contribution only makes sense with your private content in it, it belongs in your fork, not here.
+
+## Conventions
+
+- Markdown for commands, skills, ops, and docs.
+- Commands and skills lead with a clear, specific `description` — it's the trigger.
+- Hooks must run with no setup and no secrets. Make destructive or blocking behavior obvious.
+- Keep the README skimmable; put depth in `docs/`.
+
+## Before you open a PR
+
+- Run `/demo-briefing` and confirm it still works.
+- Install and trip the commit guard: `ln -s ../../.claude/hooks/pre-commit-guard.sh .git/hooks/pre-commit`, then try committing a fake key — it should block.
+- Keep the diff focused; one idea per PR.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,121 @@
 # Claude Code Growth OS
-Growth Operating System (OS): Sales, Marketing, Product and Retention as one Revenue system
+
+**Run your whole go-to-market inside Claude Code — not just your code.**
+
+![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
+![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-d97757)
+![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
+
+Most people ask Claude Code to write code. You can also run your go-to-market in it: let it read your plain-text playbooks, run your daily rituals — the morning briefing, follow-ups, lead qualification, content — and reach your tools, so the whole motion runs from one place. Because everything is markdown in git, your sales & marketing system gets a diff, a history, and a blame view, and it stops living in your head.
+
+Most sales & marketing skill packs just generate copy. This runs the operating day around it — qualify, prep, follow up, post — and keeps it all in git.
+
+This repo is the scaffolding: opinionated hooks, daily rituals, a set of go-to-market skill templates spanning all four functions, and a worked example you can run in 30 seconds. **Bring your own playbooks — the structure is here.**
+
+**Why one repo for the whole motion?** The buyer merged it — they research, buy, adopt, and renew as one relationship, and most of a B2B decision happens before sales is even in the room. Running marketing, sales, product, and retention as four separate systems is what creates the seams the buyer feels — and leaves the most valuable half, what happens *after* the sale, with no owner. This kit keeps all four in one place: one source of truth (the repo), two feedback loops (a `MARKETING-ACTION` line for sales→marketing, a `RETENTION-RISK` line for post-sale→product), shared definitions. The one-page argument, with sources, is in [`docs/why-align.md`](docs/why-align.md).
+
+## See it run in 30 seconds
+
+Clone, open in Claude Code, and run `/demo-briefing`. It runs the whole morning ritual against the fictional sample data in `demo/`:
+
+```
+Top 3 for today
+1. Unstick Rheinkraft Manufacturing — 8 days quiet in Negotiation, no next step.
+   Send a hold + a one-line "still worth doing?" today.            (advances a deal)
+2. Ship the revised Thornbury Insurance proposal (two contexts) —
+   committed for Friday. Draft this morning.                       (a commitment)
+3. Start one new conversation — pick a target, send one note.      (outbound)
+
+⚠ Slipping: Rheinkraft Manufacturing (DE) — Negotiation, 8 days no activity, no next step.
+
+Tasks pulled from yesterday's meetings
+- [Thornbury] Send revised two-context proposal           — due Fri
+- [Thornbury] Intro Oliver to an insurance reference customer
+- [Thornbury] Share the security overview pack
+- [Cascadia] Send the ROI one-pager                       — before Wed
+- [Cascadia] Confirm discovery invite incl. her two analysts
+
+Flagged for marketing (loop 1: sales → marketing)
+⚑ "How is this different from the BI tool we already have?" — 3rd time this month → needs a one-pager
+
+Flagged for product (loop 2: post-sale → product)
+⚑ Northwind Robotics — usage down 2 weeks, only 1 of 3 workflows adopted → retention risk
+
+Pipeline: 6 deals · 1 slipping · 2 with no next step · 1 onboarding account at risk
+```
+
+Nothing there is real — delete `demo/` whenever you like.
+
+## What's inside
+
+| Piece | What it is |
+|---|---|
+| `.claude/hooks/` | Five guardrails: session-start context, **state re-injection across compaction**, a **commit secret-guard**, sensitive-file protection, an end-of-day nudge |
+| `.claude/commands/` | Daily rituals you invoke by name: `/morning-briefing`, `/midday-checkin`, `/end-of-day`, `/weekly-review`, plus `/demo-briefing` |
+| `skills/` | Skill templates grouped by the four growth functions (see below) — so the balance across marketing, sales, product, and retention is visible, not acquisition-only |
+| `ops/` | Your plain-text playbooks — `priorities.md`, `daily-log.md`, `pipeline.md` (left side), `customers.md` and `roadmap-signals.md` (right side). Start here. |
+| `demo/` | A fictional pipeline *and* customer book so you can see the whole motion work (and present from it safely) |
+| `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (NRR), and the three shared definitions |
+| `docs/methodology.md` | The idea in full: Claude Code as an operating environment |
+| `docs/why-align.md` | The one-page argument: why your whole go-to-market (marketing, sales, product, retention) runs as one system (with sources) |
+
+**Skills by function** — the motion is balanced across the bowtie, not just acquisition:
+
+| Function | Skills |
+|---|---|
+| **Marketing / Demand** | `content-repurpose`, `marketing-feedback` (sales→marketing loop) |
+| **Sales** | `lead-qualify`, `meeting-prep`, `follow-up`, `cold-outreach` |
+| **Product** | `product-signal` (routes field + retention signals to the roadmap; writes the buyer-facing line for anything shipped) |
+| **Retention** | `onboarding-handoff` (Won→onboarding), `account-health` (adoption, renewal motion, churn/expansion), `retention-feedback` (post-sale→product loop) |
+| **Cross-cutting** | `status-update`, `triage` |
+
+## How it fits together
+
+One loop, all plain text in git:
+
+1. **Open a session** → the SessionStart hook surfaces today's priorities.
+2. **`/morning-briefing`** reads your priorities, yesterday's log, and your pipeline → today's top three.
+3. **Through the day**, the skills work on your own data — on both sides of the bowtie. *Left side:* `lead-qualify` a new opportunity, `meeting-prep` before a call, `follow-up` after it, `cold-outreach` to a prospect, `content-repurpose` a win into posts, `marketing-feedback` to turn a recurring objection into a note marketing acts on. *Right side:* `onboarding-handoff` when a deal is won (carry the value hypothesis across the seam), `account-health` to score adoption and start the renewal motion at day 60, `product-signal` to route retention and field signals to the roadmap, and `retention-feedback` to turn an adoption slip into a signal product acts on.
+4. **`/end-of-day`** logs what shipped and sets tomorrow; **`/weekly-review`** finds the patterns across both sides — renewals due, accounts at risk, expansion candidates, and the top roadmap signals.
+5. **The hooks hold it together** — your state survives a long session (`pre-compact`), and nothing secret slips into a commit (`pre-commit-guard`).
+
+The left side lives in `ops/pipeline.md`; the right side in `ops/customers.md` (the post-sale account book) and `ops/roadmap-signals.md` (product's triage queue). Priorities and notes round it out — all yours, with a fictional copy in `demo/`. Edit the markdown, commit, and your whole go-to-market has a history. The handoffs that connect the four functions are mapped in [`docs/operating-model.md`](docs/operating-model.md).
+
+## Quickstart
+
+1. Clone and open in Claude Code. The SessionStart hook surfaces `ops/priorities.md` immediately.
+2. Run `/demo-briefing` to see the loop on sample data.
+3. Edit `ops/priorities.md` with your own, run `/morning-briefing`, and commit. That's the loop.
+4. Install the commit secret-guard once: `ln -s ../../.claude/hooks/pre-commit-guard.sh .git/hooks/pre-commit`
+
+## The hooks earn their place
+
+- **`pre-compact.sh`** re-injects your priorities and latest log when a long session compacts — your state lives in files, so the context window can't lose the thread.
+- **`pre-commit-guard.sh`** blocks a commit if staged changes look like they contain a secret (API keys, private keys, tokens).
+- **`protect-files.sh`** stops the agent writing to `.env`, keys, and credentials.
+- **`session-start.sh`** and **`stop-reminder.sh`** open and close the day.
+
+All pure bash (one uses `python3` to read a payload). No API keys, no MCP — it runs anywhere out of the box.
+
+## Make it yours
+
+- **`ops/`** — one file per area. Don't port your whole life on day one; pick the ritual you dread most and make it real.
+- **`.claude/commands/`** — a ritual is just a markdown prompt. Copy one and tweak it.
+- **`skills/`** — a repeatable job, triggered by its `description`. Copy one of the included skills as a pattern.
+- **Connect your tools** — add MCP servers (calendar, notes, issue tracker, CRM) via a local `.mcp.json` and let your commands reach them.
+
+## Portability
+
+The `skills/` and `commands/` are plain markdown on the Agent Skills spec, so they port to Cursor, Windsurf, and Codex with little change. The `hooks/` and `settings.json` are Claude-Code-specific — they won't carry over, and that's fine; the rituals and skills are the part worth taking elsewhere.
+
+## What's deliberately not here
+
+No real playbooks, positioning, pricing, or data. That's the point: the structure is reproducible; the judgment you put inside it is the part that's yours. Fill one drawer this week.
+
+## Who's behind this
+
+I'm Edwin Trebels — I run a company's entire go-to-market on a setup like this. This repo is the open skeleton. The full version adds the wider automation layer — n8n handling vendor management, ICP checks, pre-meeting briefings, post-meeting debriefs and follow-ups, and the assistant that keeps the day straight; Blackbird.io for multilingual content — plus the judgment that fills the empty drawers. That part took twenty-one years and doesn't come in a folder.
+
+Want it built and run for you, or a growth operator who works this way? That's what I do: [langoptima.com/growth](https://langoptima.com/growth). The thinking behind the kit is in [`docs/methodology.md`](docs/methodology.md).
+
+**If it's useful, a ⭐ helps others find it.** PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). MIT licensed.

--- a/demo/customers.md
+++ b/demo/customers.md
@@ -1,0 +1,16 @@
+# Customers — sample data
+
+> Every account below is fictional. This is the right-side mirror of
+> `demo/pipeline.md` — the post-sale account book, once a deal is won. Replace
+> with your own, or delete the whole `demo/` folder when you make this yours.
+>
+> Stage: Onboarding → Adopting → Live → At-Risk → Expanding. The renewal motion
+> starts at **day 60**, not day 85 — the renewal date is the clock to watch.
+
+| Account | Stage | Value hypothesis | Key adoption signal | Renewal date | Owner | Next step |
+|---|---|---|---|---|---|---|
+| Northwind Robotics | 🔴 At-Risk | Cut cross-system lookup time for ops engineers | Usage down 2 weeks; 1 of 3 workflows live; champion quiet after reorg | 2026-09-30 | CS | Re-map stakeholders, find a power user — renewal clock opens day 60 |
+| Halden Maritime | 🟡 At-Risk | One view of vessel data across port systems | Steady usage, but renewal case blocked on a missing export feature | 2026-07-15 | CS | Chase roadmap status on export; renewal motion already open (inside day 60) |
+| Cascadia BioSciences | 🟢 Adopting | Answer cross-system research questions in minutes | Two analysts onboarded; first workflow live, second in setup | 2026-11-30 | CS | Confirm second workflow milestone; watch for the day-60 marker |
+| Meridian Health | 🟢 Expanding | Connect clinical data across departments | Healthy in the first department; a second asked for access unprompted | 2026-10-31 | CS + Sales | Hand expansion signal to sales with the CS context attached |
+| Thornbury Insurance | 🟢 Onboarding | One compliance view across two business contexts | Kickoff done; first context being configured; champion engaged | 2026-12-15 | CS | Set first adoption milestone; carry the two-context value hypothesis forward |

--- a/demo/daily-log.md
+++ b/demo/daily-log.md
@@ -1,0 +1,8 @@
+# Daily Log — sample data
+
+<!-- Fictional. Newest entry at the top. -->
+
+## 2026-05-22
+- Shipped: Thornbury Insurance pricing call; Cascadia BioSciences discovery booked; flagged Northwind Robotics adoption slip to product (1 of 3 workflows live).
+- Slipped: Rheinkraft Manufacturing follow-up — now 8 days quiet; Northwind re-engagement still not scheduled after the reorg.
+- Learned: two-context proposals land better than one; a won deal still needs a real onboarding owner or adoption stalls.

--- a/demo/feedback-log.md
+++ b/demo/feedback-log.md
@@ -1,0 +1,31 @@
+# Demo — GTM Feedback Log (fictional)
+
+The two loops that keep the whole motion in sync, in one file. **Nothing here is real** — these are made-up companies.
+
+- **Field intel → marketing** (`MARKETING-ACTION`) — what sales hears, handed to marketing.
+- **Retention signal → product** (`RETENTION-RISK`, `EXPANSION-SIGNAL`, `FEATURE-REQUEST`) — where customers stall, grow, or ask for something after the sale, handed to product/CS.
+
+The `marketing-feedback` and `retention-feedback` skills write lines like these; `product-signal` pulls the product-shaped ones (`FEATURE-REQUEST`, roadmap-worthy `RETENTION-RISK`) into `ops/roadmap-signals.md`. This is the raw cross-function loop; `roadmap-signals.md` is product's triaged queue downstream of it. One file, every function — that's the loop, version-controlled.
+
+## Field intel → marketing
+
+### 2026-05-22
+- `MARKETING-ACTION`: "How is this actually different from the BI tool we already have?" came up again at **Cascadia BioSciences** — third time this month. Needs a one-pager that answers it without a feature list. (buyer language: they keep saying *"another dashboard"*)
+- `MARKETING-ACTION`: **Rheinkraft Manufacturing** asked for a manufacturing reference customer we don't have published yet. Missing proof point.
+- `MARKETING-STRATEGIC`: Two insurance prospects this month framed the problem as *"compliance,"* not *"efficiency."* Worth testing compliance-led messaging for that segment.
+
+### 2026-05-20
+- `MARKETING-ACTION-URGENT`: Momentum stalled at **Thornbury Insurance** partly because a competitor's published case study did the convincing we couldn't match. We need a comparable proof asset.
+- `MARKETING-ACTION`: Recurring buyer language — prospects say *"single source of truth"* far more than *"integration."* Mirror their words in the next campaign.
+
+## Retention signal → product
+
+### 2026-05-22
+- `RETENTION-RISK`: **Northwind Robotics** (signed Q1, in onboarding) — weekly active usage down two weeks running; they've only adopted one of the three workflows in scope. Adoption friction → product. The stall is at the second workflow's setup step.
+- `RETENTION-RISK`: **Halden Maritime** (production) — asked twice for an export feature that doesn't exist; it's now blocking their renewal case. Feature request that affects retention → roadmap, not the backlog void.
+- `FEATURE-REQUEST`: **Halden Maritime** — the blocking item, stated plainly for the roadmap: export the connected view to their reporting tool. Tied to the renewal above. (product-signal routes this to `roadmap-signals.md`)
+- `FEATURE-REQUEST`: **Cascadia BioSciences** (adopting) — asked for saved, re-runnable views so analysts don't rebuild a query each time. Recurred across a few accounts now — a pattern, not a one-off.
+
+### 2026-05-19
+- `RETENTION-RISK`: **Northwind Robotics** — champion (their ops lead) went quiet after a reorg; no power user identified yet. Single-threaded post-sale → CS to re-map stakeholders before renewal (day 60, not day 85).
+- `EXPANSION-SIGNAL`: **Meridian Health** (production, healthy) — a second department asked for access unprompted. Expansion pattern → hand to sales with the CS context attached.

--- a/demo/meetings/2026-05-22-cascadia-biosciences.md
+++ b/demo/meetings/2026-05-22-cascadia-biosciences.md
@@ -1,0 +1,22 @@
+---
+type: meeting
+title: Cascadia BioSciences — discovery prep call
+date: 2026-05-22
+participants: [You, Dana Whitfield (VP Data, Cascadia BioSciences)]
+---
+
+# Cascadia BioSciences — discovery prep call (2026-05-22)
+
+> Fictional sample meeting note.
+
+## Summary
+Short intro call before Wednesday's discovery. Dana flagged that their research
+data sits across three systems and nobody can answer cross-system questions
+quickly.
+
+## Commitments (you)
+- Send the ROI one-pager ahead of Wednesday.
+- Confirm the discovery call invite with her two analysts included.
+
+## Next step
+Discovery call Wednesday.

--- a/demo/meetings/2026-05-22-thornbury-insurance.md
+++ b/demo/meetings/2026-05-22-thornbury-insurance.md
@@ -1,0 +1,23 @@
+---
+type: meeting
+title: Thornbury Insurance — pricing discussion
+date: 2026-05-22
+participants: [You, Oliver Hartley (Underwriting Director, Thornbury Insurance)]
+---
+
+# Thornbury Insurance — pricing discussion (2026-05-22)
+
+> Fictional sample meeting note.
+
+## Summary
+Walked through the pilot scope. Oliver wants the proposal revised to cover two
+business contexts instead of one, plus a reference from an insurance customer
+before he takes it to his board.
+
+## Commitments (you)
+- Send a revised proposal covering two contexts by Friday.
+- Introduce Oliver to an insurance reference customer.
+- Share the security overview pack.
+
+## Next step
+Pricing review Thursday.

--- a/demo/pipeline.md
+++ b/demo/pipeline.md
@@ -1,0 +1,19 @@
+# Pipeline — sample data
+
+> Every company below is fictional. This is the safe sandbox for seeing the
+> ritual run (and for presenting from). Replace with your own, or delete the
+> whole `demo/` folder when you make this yours.
+>
+> The left side of the bowtie. When a deal is marked **Closed-Won**, it crosses
+> the H3 seam: `onboarding-handoff` opens its first row in `demo/customers.md`,
+> carrying the value hypothesis forward — see Northwind Robotics below, now in
+> the post-sale book.
+
+| Account | Region | Stage | Last activity | Next step | Health |
+|---|---|---|---|---|---|
+| Northwind Robotics | United States | Closed-Won | Signed Q1 | Handed to CS → now in `customers.md` (onboarding) | ✅ Won — see post-sale book |
+| Rheinkraft Manufacturing | Germany | Negotiation | 8 days ago | — none set — | 🔴 Tier-1, slipping |
+| Thornbury Insurance | United Kingdom | Proposal | 2 days ago | Pricing review Thursday | 🟢 |
+| Cascadia BioSciences | United States | Discovery | 1 day ago | Discovery call Wednesday | 🟢 |
+| Borealis Energy | Canada | Evaluation | 4 days ago | Send security pack | 🟡 |
+| Tasman Financial Group | Australia | Discovery | 11 days ago | Re-engage champion | 🟡 |

--- a/demo/priorities.md
+++ b/demo/priorities.md
@@ -1,0 +1,8 @@
+# Priorities — sample data
+
+<!-- Fictional. For the demo / for presenting from. -->
+
+1. Get the Rheinkraft Manufacturing negotiation unstuck — it's gone quiet.
+2. Revised Thornbury Insurance proposal out by Friday.
+3. Re-engage Northwind Robotics — adoption is slipping post-sale; find a power user before the renewal clock opens.
+4. Start one new conversation this week.

--- a/demo/roadmap-signals.md
+++ b/demo/roadmap-signals.md
@@ -1,0 +1,17 @@
+# Roadmap Signals — sample data
+
+> Every entry below is fictional. This is **product's triage queue** — distinct
+> from `demo/feedback-log.md`, which is the raw cross-function loop. The log is
+> where signals land as sales and CS hear them; this is where product pulls the
+> ones that shape the roadmap and routes each. The `product-signal` skill moves
+> items from the log to here.
+>
+> Status: New → Routed → Shipped. Once something ships, the last column carries
+> the one-line "what this means for the buyer" — so the feature doesn't land silently.
+
+| Date | Source signal | Type | Tied to | Routed to | Status | What it means for the buyer (once shipped) |
+|---|---|---|---|---|---|---|
+| 2026-05-22 | Export feature asked for twice; now blocking renewal | FEATURE-REQUEST | Halden Maritime (renewal) | Roadmap — next cycle | Routed | — |
+| 2026-05-22 | Stall at the second workflow's setup step | Adoption friction | Northwind Robotics (onboarding) | Product — onboarding flow | New | — |
+| 2026-05-20 | Lost momentum partly on a missing comparison capability | Win/loss (product) | (lost-deal pattern) | Product + marketing | New | — |
+| 2026-05-12 | Saved-views feature requested across 3 accounts | FEATURE-REQUEST | Multiple (expansion) | Roadmap — shipped | Shipped | You can save and re-run your common views — no rebuilding a query each time. |

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,0 +1,42 @@
+# Claude Code as an operating environment
+
+A short argument for using Claude Code to run your work, not just write your code.
+
+## The shift
+
+Most people reach for Claude Code as something to *ask* — a faster way to write the next thing. Useful, but it leaves it as a tool you visit. The shift is to treat it as the room you work *in*: the place your day starts, your rituals run, and your tools get reached. Your CRM, your notes, your calendar, your issue tracker stop being places you go. They become things the room reaches for you.
+
+This kit is set up for the whole go-to-market — all four functions across both sides of the bowtie: marketing and sales on the left (the demo pipeline, the qualification / prep / follow-up / outreach / content skills), product and retention on the right (the customer book, the onboarding handoff, account health, the roadmap-signals queue). But the pattern isn't go-to-market-specific: the same shape runs a research practice, a support queue, a founder's week. If you have recurring work and scattered tools, it applies. The mechanics of the four-function motion — the handoffs, the one number, the shared definitions — live in [`operating-model.md`](operating-model.md); this page is about the *environment* they run in.
+
+## Four ideas that make it work
+
+**1. State lives in plain text, in git.** Your playbooks, priorities, and log are markdown files, not rows in someone's database. That sounds modest until you notice the consequences: your operating system has a diff, a history, and a blame view. You can read it, fork it, and fix it in a text editor. And when a long session's context window compacts, nothing important is lost — it's still on disk, and a hook re-injects it.
+
+**2. Rituals are commands.** A recurring task — a morning briefing, an end-of-day close — becomes a slash command: a short markdown prompt you invoke by name. The sequence is the system. You stop re-deciding how to start the day and just run it.
+
+**3. Guardrails are hooks.** The unglamorous safety net — don't commit a secret, don't write to `.env`, don't lose state on compaction — lives in hooks that run on events, not in your memory. Build the guardrail once; it holds every session after.
+
+**4. One ritual at a time.** The failure mode is porting your whole working life on day one, then abandoning it. Pick the task you dread most. Make it a command. Run it daily for a week. Then add the next. Compounding comes from small reps, not a heroic weekend.
+
+## Why this is one system, not four
+
+The kit runs all four go-to-market functions — marketing, sales, product, retention — in one repo on purpose. The buyer already merged them: they research, buy, adopt, and renew as one relationship, and most of a B2B decision now happens before sales is in the room. Drawn honestly the journey isn't a funnel that ends at the sale; it's a bowtie, with the post-sale half (onboarding, adoption, renewal, expansion) usually left with no owner. Running the four as separate systems is what creates the seams the buyer feels. The fix is structural, not cultural, and the four ideas above happen to be it:
+
+- **One source of truth** → the git repo. Every function reads and writes the same markdown — not four tools with four versions of the truth.
+- **Two feedback loops** → the `marketing-feedback` skill plus a `MARKETING-ACTION` line (sales→marketing), and the `retention-feedback` skill plus a `RETENTION-RISK` line (post-sale→product). What the field and the customer base surface becomes an action in the same system, the same day — version-controlled.
+- **Shared definitions** → a "qualified lead," and what "ready to hand off at won" means, are each one file every function edits, not four arguments.
+- **Shared rituals** → the briefing and review commands run the joint motion across all four, not a relay of hand-offs.
+
+You don't need a RevOps platform to get this. You need one place the whole motion lives. The mechanics — the six handoffs, the one number (NRR), the three shared definitions — are in [`operating-model.md`](operating-model.md); the one-page argument, with sources, is in [`why-align.md`](why-align.md).
+
+## What stays out
+
+The structure is reproducible and worth sharing. The judgment you encode inside it — your actual playbooks, your positioning, your numbers, your relationships — is not, and shouldn't be. A starter hands you the empty cabinet on purpose. The drawers are yours to fill, and what you fill them with is the part no template can give you.
+
+## Where it breaks (because it does)
+
+- **Long sessions drift.** Hence the compaction hook — but it only re-injects what you've written down. Garbage in, garbage out.
+- **Skill and command sprawl.** Add only what you use; cut the rest on a cadence.
+- **It runs on discipline.** The system doesn't run you. You run it. A ritual you don't run is a file, not a habit.
+
+That's the whole idea. Start with one ritual. See `../README.md` to run it.

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -1,0 +1,69 @@
+# The Operating Model
+
+How the four functions run as one motion in this kit. [`why-align.md`](why-align.md) is the *argument* — why marketing, sales, product, and retention belong in one system. This is the *spine* — the handoffs, the one number, and the shared definitions that make it run. The two are meant to be read together.
+
+> The figures below are directional and attributed where used. Treat the **direction** as well-supported and the **magnitudes** as soft. Sources are in [`why-align.md`](why-align.md#sources).
+
+## The bowtie, not the funnel
+
+Draw the customer journey honestly and it isn't a funnel that ends at the sale — it's a **bowtie**. The left half is what most teams instrument: demand and acquisition. The right half is the one the funnel forgets: onboarding, adoption, renewal, expansion. **Two of the three ways a company grows happen after the first sale** (Winning by Design). That right half is where net revenue retention lives — and a leaking bucket can't be filled by pouring in more acquisition.
+
+So the seams a buyer feels aren't only marketing↔sales. They're sales↔the product received, and product↔whether anyone helps the customer get value. Four hands on one motion, not four stages of a relay.
+
+## The four functions
+
+| Function | Owns | On the bowtie |
+|---|---|---|
+| **Marketing / Demand** | Awareness, demand, the buyer's first surfaces | Left — top |
+| **Sales** | Qualification, the deal, the close | Left — bottom |
+| **Product** | What the customer actually receives and adopts | Center — the knot |
+| **Retention** | Onboarding, adoption, renewal, expansion | Right |
+
+Run as four separate systems, each optimizes its own metric at the others' expense. Run as one, the signal compounds: what sales hears shapes marketing; what customers do shapes product; what product ships re-arms sales.
+
+## The six handoffs
+
+A motion is only as strong as its handoffs. Each one has a **trigger**, an **owner**, and an **artifact** — the place it's written down so it can't drop.
+
+| # | Handoff | Trigger | Owner | Artifact |
+|---|---|---|---|---|
+| **H1** | Marketing → Sales | A lead clears the MQL→SQL bar | Marketing | A qualified lead in `ops/pipeline.md` |
+| **H2** | Sales → Marketing | Sales hears a recurring objection, competitor, missing proof, or win/loss reason | Sales | A `MARKETING-ACTION` line in the feedback log (`marketing-feedback`) |
+| **H3** | Won → Onboarding | A deal is marked won | Sales → CS | The first `ops/customers.md` row, with the value hypothesis carried forward (`onboarding-handoff`) |
+| **H4** | CS → Product | Adoption friction, a churn reason, or a request blocking adoption/expansion | CS | A routed item in `ops/roadmap-signals.md` (`product-signal`) |
+| **H5** | Product → GTM | A capability ships | Product | The one-line "what this means for the buyer" in `ops/roadmap-signals.md`, handed to sales and marketing (`product-signal`) |
+| **H6** | CS → Marketing | A customer reaches a clear outcome | CS | A reference / proof point — the customer's own words for the value they got |
+| **L** | Loop close | Weekly review | All four | `MARKETING-ACTION` cleared, `RETENTION-RISK` routed, references captured — read in `/weekly-review` |
+
+H1 and H2 are the loop most teams can see. H3–H6 are the right side of the bowtie — the half usually left with no owner. **H3 is the seam most teams never define**: a signed deal that drops into a CS void with no shared definition of *ready*. **H5 is the antidote to "build it and they will come"** — an often-cited rule of thumb is that ~80% of shipped features go rarely or never used, largely because they ship with no enablement and no buyer-facing reason to adopt them.
+
+## The one number, and a North Star
+
+- **One revenue number: net revenue retention (NRR).** The whole bowtie rolls up to it. Median NRR sits around ~106% (ChartMogul / SaaS benchmarks); below 100% means acquisition spend is filling a leaking bucket. It's the financial number that now decides what a company is worth — and the reason the right side of the bowtie can't be an afterthought.
+- **A North Star that captures customer value** — the leading indicator of NRR, specific to your product (the action that means a customer is getting value, counted across the base). NRR is the lagging financial truth; the North Star is the thing you can move this week.
+
+One shared number beats four local metrics — lead volume, bookings, ship count, tickets closed — that conflict the first time a target slips.
+
+## Three shared definitions
+
+Written once, owned jointly, living as one file each — not four arguments in four tools.
+
+1. **One ICP.** Who you're for, agreed by sales and marketing in the same room. (`ops/icp.md` if you keep one — `lead-qualify` reads it.)
+2. **One MQL→SQL bar.** The single definition of a qualified lead both sides own — the H1 trigger. (Only ~8% of B2B firms even share this definition; documented SLAs correlate with ~34% higher odds of higher YoY ROI.)
+3. **One Won→onboarding definition.** What "ready to hand off" means — the H3 trigger and checklist, so a closed deal doesn't drop silently. (`onboarding-handoff` runs it.)
+
+## How this kit maps to the model
+
+You don't need a platform — a plain-text repo run from Claude Code *is* the operating model:
+
+- **One source of truth** → the git repo. Every function reads and writes the same markdown.
+- **The handoffs** → `ops/pipeline.md` (H1), the feedback log (H2, H6), `ops/customers.md` (H3), `ops/roadmap-signals.md` (H4, H5).
+- **The skills** → `marketing-feedback` (H2), `onboarding-handoff` (H3), `account-health` (the right-side operating loop), `product-signal` (H4/H5), `retention-feedback` (the post-sale→product loop).
+- **The rituals** → `/demo-briefing` and `/weekly-review` run the joint motion and close the loop (L) across all four.
+
+The mature version of this is RevOps — one operating model and one data spine for the whole motion. At a founder-led stage the fix is to *close the loop*, not to hire a RevOps team: keep all four functions learning in one place and document the motion before you delegate it.
+
+## See also
+
+- [`why-align.md`](why-align.md) — the one-page argument, with sources, for why the four belong in one system.
+- [`methodology.md`](methodology.md) — Claude Code as the operating environment the model runs in.

--- a/docs/why-align.md
+++ b/docs/why-align.md
@@ -1,0 +1,109 @@
+# Why Your Whole Go-to-Market Belongs in One System
+
+Most companies run growth as four departments that hand off down a line: marketing generates demand, sales closes it, product builds, customer success keeps the account. The buyer stopped experiencing it that way — they research, buy, adopt, and renew as one continuous relationship, and they don't care about your org chart. That single change is why coordination *across all four* has moved from "nice to have" to a measurable driver of growth.
+
+This kit keeps the whole motion in one repo on purpose. This page is the *why*: why the four belong together, why they drift apart anyway, what "working together closely" actually means, and how to start.
+
+> The exact percentages below come from a mix of studies and vary by source. The **direction** is well-supported; treat the **magnitudes** as directional, not benchmark-grade.
+
+---
+
+## 1. There is one motion, not four
+
+The old model was a relay: marketing creates awareness and generates leads, sales takes over and sells, and what happens after the contract is signed is somebody else's problem. That assumed the buyer entered a conversation with a rep early, and that the sale was the finish line.
+
+Neither holds. The share of the B2B buying journey that happens **before any contact with sales** has climbed steadily — roughly 57% in 2015, ~70% by 2019, and ~80% by 2024. Gartner reports **67% of B2B buyers now prefer a rep-free buying experience**. So most persuasion happens on surfaces marketing owns, long before sales is in the room.
+
+And the finish line moved too. Draw the journey honestly and it isn't a funnel — it's a **bowtie**: demand and acquisition on the left, then the *wide* right half the funnel usually forgets — onboarding, adoption, renewal, expansion. Two of the three ways a company grows happen *after* the first sale. That's where **net revenue retention** lives — the number that now decides what a company is worth.
+
+So the seams a buyer feels aren't only between marketing and sales. They're between sales and the product they actually receive, and between the product and whether anyone helps them get value from it. Marketing, sales, product, and customer success are no longer four stages of a relay. They are four hands on one continuous motion.
+
+## 2. What the evidence shows
+
+**Aligning sales and marketing already pays — that's the part most people have heard:**
+
+- SiriusDecisions (now Forrester) benchmarked roughly 400 B2B organizations: tightly aligned sales and marketing achieved **~24% faster three-year revenue growth and ~27% faster profit growth** — the most credible single figure in the literature.
+- IDC estimates the inability to align costs **10%+ of revenue per year**; broader estimates of revenue lost to siloed data and functions run **20–30%**. LinkedIn's "Art of Winning" puts the US aggregate near **$1 trillion a year**.
+- A concrete waste line: **60–70% of the content marketing produces is never used by sales.**
+
+**The bigger, less-told leak is on the right side of the bowtie:**
+
+- **Net revenue retention is the valuation number.** Median NRR sits around **~106%** (higher for enterprise, lower for SMB). Below 100% means every dollar of acquisition spend is filling a leaking bucket — you grow by running faster, not by compounding.
+- **Premature scaling is the #1 startup killer.** Studies of high-growth startups attribute roughly **70%+ of failures** to scaling before the motion works — pouring acquisition into a product or post-sale experience that can't hold it.
+- **The feedback that would fix it gets lost.** Sales reps **misdiagnose why deals are won or lost 60–85% of the time**, so the real reason rarely reaches marketing or product. And an often-cited rule of thumb is that **~80% of shipped features go rarely or never used** — product building without the signal from the field and the customer base.
+
+Put together: the cost of misalignment isn't only the deals marketing and sales fumble between them. It's the renewals product never hears about and the expansions customer success never triggers.
+
+## 3. Why it persists: the perception gap and the post-sale blind spot
+
+If the case is this clear, why is it still rare? Two reasons.
+
+**The people who could fix the front half think it's already fixed.** Forrester's 2024 survey: **82% of C-level executives believed sales and marketing were in sync, while 65% of the practitioners reported the opposite.** Only about **8%** of companies are strongly aligned. The people on the ground see the seam daily; the people with authority to close it don't.
+
+**And almost nobody instruments the back half.** Acquisition gets the dashboards; the post-sale motion gets wired last, if at all — so churn happens for reasons that never reach the roadmap, and expansion is left to chance. The most expensive gap is the one with no owner.
+
+## 4. Why teams drift apart (it's structural, not personal)
+
+It's tempting to treat this as a relationship problem — get the teams in a room. That rarely holds, because the forces pulling them apart are structural while the usual fixes are behavioral. People act rationally inside the system they're given; when the system is split four ways, collaboration breaks under pressure.
+
+- **Split incentives.** Marketing is measured on lead *volume*, sales on *bookings*, product on *ship count*, CS on *tickets closed*. Four local metrics, optimized separately, that conflict the first time a target slips.
+- **One-sided definitions.** When one team alone defines a "qualified lead" — or when "closed-won" hands off to onboarding with no shared definition of *ready* — you get the standoff and the silent drop.
+- **Separate tools and data.** Four systems, four versions of the truth; meetings become reporting disputes instead of decisions.
+
+Goodwill can't out-run a broken incentive system. If you want different behavior, change the structure.
+
+## 5. What "working together closely" actually means
+
+Not constant meetings or a merged org chart — a small set of shared structures. The same handful that aligns sales and marketing extends to all four:
+
+1. **Shared definitions, written once.** One ICP. One MQL→SQL bar both sales and marketing own. One **Won→onboarding handoff** so a signed deal doesn't drop silently into a CS void. (Only ~8% of B2B firms even share an MQL/SQL definition; firms with documented SLAs are ~34% more likely to see higher YoY ROI.)
+2. **Two-way commitments (SLAs).** Marketing commits to lead volume *and quality*; sales commits to follow-up speed *and honest feedback*; sales commits to a complete handoff at won; CS commits to flag risk early (the renewal motion starts day 60, not day 85).
+3. **Shared goals — one revenue number.** A North Star that captures customer value, with **NRR** as the financial number the whole bowtie rolls up to. Not four separate local targets that pull apart.
+4. **One source of truth.** A shared system with closed-loop reporting, so all four reason from the same numbers.
+5. **Two standing feedback loops.** Field intelligence flows from sales back to marketing (objections, competitor language, missing proof, win/loss reasons). And retention intelligence flows from CS back to product (adoption friction, churn signals, expansion blockers) — and back to marketing as references and proof.
+6. **Predictable rituals.** A regular joint review, so alignment is a habit, not an offsite.
+
+The mature version is **RevOps** — running marketing, sales, and customer success on one operating model and one data spine. The fix at a founder-led stage is to *close the loop*, not hire a RevOps team: keep all four functions learning in one loop and document the motion before delegating it.
+
+### How this kit maps to the structure
+
+You don't need a platform to get most of this. A plain-text repo, run from Claude Code, *is* the structure. The mechanics — the six handoffs (H1–H6), the one number, and the three shared definitions — are laid out in [`operating-model.md`](operating-model.md); the short version:
+
+- **One source of truth** → the git repo. Every function reads and writes the same markdown.
+- **Two feedback loops** → the [`marketing-feedback`](../skills/marketing-feedback/SKILL.md) skill (`MARKETING-ACTION`, sales→marketing) and the [`retention-feedback`](../skills/retention-feedback/SKILL.md) skill (`RETENTION-RISK`, post-sale→product). Both write tagged lines to the same log — version-controlled, with a diff and a history.
+- **One shared definition** → the ICP, the MQL→SQL bar, and the Won→onboarding handoff are each one file every function edits, not four arguments in four tools.
+- **Shared rituals** → the briefing and review commands run the joint motion across all four.
+
+## 6. A starter checklist
+
+Start small and structural rather than cultural:
+
+- [ ] **Write one shared ICP and lead definition**, agreed by sales and marketing in the same room. Put it in `ops/`.
+- [ ] **Write the Won→onboarding handoff** — the one checklist a closed deal must complete before CS owns it. This is the seam most teams never define.
+- [ ] **Pick one shared number** the whole motion rolls up to — NRR or revenue, not four local metrics in isolation.
+- [ ] **Agree on one source of truth** for that number. One place, not four.
+- [ ] **Open both loops.** A dead-simple way for sales to log field intel (`marketing-feedback`) *and* for CS to log adoption/churn signals (`retention-feedback`), each with a standing slot for marketing and product to act.
+- [ ] **Schedule one recurring review** with all four functions represented.
+
+You don't need everything on day one. A shared definition, a Won→onboarding handoff, and a single shared number already remove most of the friction. Fill the drawer you're most blind to first — for most teams, that's the post-sale half.
+
+## 7. Honest caveats
+
+- **The exact percentages are soft.** Several of the most-quoted figures come from older or vendor-sponsored studies and vary between sources. Use them to make the case, not as guarantees. (One widely repeated "aligned orgs grow 36% faster" line is untraceable to a primary source — the 24% Forrester figure is the defensible one.)
+- **Correlation isn't proof of causation.** Well-run companies tend to do both alignment *and* growth well, so some of the effect is selection. Treat alignment as necessary, not single-handedly sufficient.
+- **It matters most in considered B2B sales with real post-sale relationships** — long journeys, multiple stakeholders, renewals and expansion. For low-consideration or one-off purchases, the right-side payoff is smaller.
+
+---
+
+## Sources
+
+- Gartner — 67% prefer a rep-free experience; ~80% of the journey before sales; RevOps guidance
+- Forrester / SiriusDecisions — the ~24% alignment economics; the 82%/65% perception gap; ~8% strongly aligned
+- IDC — cost of misalignment (10%+ of revenue/yr); revenue lost to silos (20–30%)
+- LinkedIn "Art of Winning" — the ~$1 trillion aggregate figure
+- Winning by Design — the bowtie model (retention and expansion as first-class growth engines)
+- ChartMogul / SaaS benchmarks — net revenue retention medians (~106%)
+- Startup Genome — premature scaling as the leading cause of high-growth startup failure
+- Clozd — reps misdiagnose win/loss reasons 60–85% of the time
+- Reforge — why funnels force siloed ownership and loops compound
+- HBR — "When Sales and Marketing Aren't Aligned, Both Suffer" (2018)

--- a/ops/customers.md
+++ b/ops/customers.md
@@ -1,0 +1,16 @@
+# Customers
+
+<!-- Your real post-sale account book — one row per signed customer. The
+     right-side mirror of ops/pipeline.md. The rituals and the account-health
+     skill read this; onboarding-handoff writes the first row when a deal is won.
+     A fictional example lives in demo/customers.md.
+
+     Post-sale stage: Onboarding → Adopting → Live → At-Risk → Expanding.
+     Value hypothesis: carry it forward from the won deal — what they bought this to do.
+     Key adoption signal: the one usage fact that says whether it's working.
+     Renewal date: the renewal motion starts at day 60, not day 85 — note the date here.
+     Next step: the single next action, with an owner. -->
+
+| Account | Stage | Value hypothesis | Key adoption signal | Renewal date | Owner | Next step |
+|---|---|---|---|---|---|---|
+| | | | | | | |

--- a/ops/daily-log.md
+++ b/ops/daily-log.md
@@ -1,0 +1,11 @@
+# Daily Log
+
+<!-- Newest entry at the top. One block per day. /morning-briefing reads the
+     most recent entry; /end-of-day appends a new one. Log work from both sides
+     of the bowtie here — deals advanced *and* post-sale touches (onboarding,
+     adoption, renewal, expansion, signals routed to product), not just deals. -->
+
+## 2026-01-01 (example — delete me)
+- Shipped: set up the ops starter
+- Slipped: nothing yet
+- Learned: a ritual only works if it runs daily

--- a/ops/pipeline.md
+++ b/ops/pipeline.md
@@ -1,0 +1,8 @@
+# Pipeline
+
+<!-- Your real pipeline — one row per active deal. The rituals and skills read this.
+     A fictional example lives in demo/pipeline.md. -->
+
+| Account | Stage | Last activity | Next step | Health |
+|---|---|---|---|---|
+| | | | | |

--- a/ops/priorities.md
+++ b/ops/priorities.md
@@ -1,0 +1,8 @@
+# Priorities
+
+<!-- The SessionStart hook surfaces this file every time you open a session.
+     Keep it to 3-5 lines. Edit it whenever your focus changes. -->
+
+1. (your top priority)
+2. (your second)
+3. (your third)

--- a/ops/roadmap-signals.md
+++ b/ops/roadmap-signals.md
@@ -1,0 +1,21 @@
+# Roadmap Signals
+
+<!-- Product's working surface — the triage queue, not the raw loop.
+
+     The shared feedback log (demo/feedback-log.md, or your own) is the raw
+     cross-function stream: everything sales and CS hear, tagged as it lands.
+     This file is downstream of it: where product *pulls* the signals that
+     should shape what gets built, and routes each one. The product-signal
+     skill moves items here from the log.
+
+     What lands here:
+     - FEATURE-REQUEST that blocks adoption or expansion (not the backlog void)
+     - churn reasons — the real one, the value the customer stopped getting
+     - win/loss reasons that are about the product, not the deal
+
+     Status: New → Routed → Shipped. When something ships, write the one-line
+     "what this means for the buyer" so the feature doesn't land silently. -->
+
+| Date | Source signal | Type | Tied to | Routed to | Status | What it means for the buyer (once shipped) |
+|---|---|---|---|---|---|---|
+| | | | | | | |

--- a/skills/account-health/SKILL.md
+++ b/skills/account-health/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: account-health
+description: Score a customer's health, start the renewal motion, and flag churn or expansion early. Trigger when the user asks "how's this account doing", "health check", "are we at risk of churn", "is this account ready to expand", or before a renewal or QBR.
+---
+
+# Account Health
+
+The right-side operating skill — the equivalent of `lead-qualify` for the post-sale half of the bowtie. Where `lead-qualify` scores a deal's fit, this scores a *customer's* health: is value landing, is the renewal safe, is there room to grow? It reads the account book and writes the signal back into the same loop the field uses.
+
+From `ops/customers.md` (or a single account the user names) and any recent post-sale notes:
+
+1. **Read the adoption signal.** Against the account's value hypothesis — is the customer getting what they bought this to do? Usage trend, workflows live vs. in scope, who's actually using it.
+2. **Score it green / amber / red:**
+   - 🟢 **Green** — using it as intended, champion engaged, value visible.
+   - 🟡 **Amber** — one warning sign (a stalled workflow, a quiet month, a single thread).
+   - 🔴 **Red** — value not landing: usage down, champion gone quiet, or single-threaded after a change.
+3. **Watch the renewal clock.** The renewal motion starts at **day 60**, not day 85. If the renewal date is inside 60 days, say so and start the motion now — don't wait for the contract to surface it.
+4. **Flag churn early-warnings.** Name the leading indicators, not the lagging one: usage trending down, the champion gone quiet, a single-threaded account after a reorg. These precede a lost renewal; the cancellation is just when it becomes visible.
+5. **Spot expansion-readiness.** A healthy account using the core well, or a second team asking unprompted, is an expansion signal — not a renewal risk.
+6. **Write the signal to the loop and update the book.** Log a tagged line in the same feedback log marketing and product read:
+   - `RETENTION-RISK: [account] — [the adoption/churn signal] → [CS or product action]`
+   - `EXPANSION-SIGNAL: [account] — [the readiness signal] → hand to sales with CS context`
+
+   Then update the account's stage, key signal, and next step in `ops/customers.md`.
+
+Don't tag every quiet week as a risk — flag it when usage, the champion, or the value story is actually slipping. A book full of false alarms gets ignored.
+
+## Depth
+- quick: the green/amber/red call + the one signal driving it.
+- standard: the full health read, renewal-clock check, and tagged loop line.
+- deep: + the churn early-warning list, the expansion read, and the day-by-day renewal-motion timing.

--- a/skills/cold-outreach/SKILL.md
+++ b/skills/cold-outreach/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cold-outreach
+description: Draft a first-touch cold email or LinkedIn DM. Trigger when the user asks for a cold email, an outreach message, or a first touch to a named prospect.
+---
+
+# Cold Outreach
+
+A first touch earns a reply by being about them, not you:
+
+1. Open with a specific, true observation about their world — no flattery, no "I came across your profile".
+2. One sentence on the problem you suspect they have — as a question, not a claim.
+3. One concrete offer of value. No calendar link in message one.
+
+Keep it under ~80 words. Bring your own proof; don't fabricate case studies or numbers.
+
+## Depth
+- quick: the message only.
+- standard: message + subject line + the one observation it hinges on.
+- deep: + a three-touch sequence, each touch a different angle (never a "just bumping this").

--- a/skills/content-repurpose/SKILL.md
+++ b/skills/content-repurpose/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: content-repurpose
+description: Turn one piece of source material into several channel-ready drafts. Trigger when the user asks to repurpose something, "turn this into posts", or "what can I make from this".
+---
+
+# Content Repurpose
+
+From a source — a win in `ops/daily-log.md`, a doc, a transcript:
+
+1. Find the one idea worth spreading — a point of view, not a summary.
+2. Draft it for the channels asked for (default: one LinkedIn post + one short X version).
+3. Keep each native to its channel; don't cross-post identical text.
+
+Lead with the idea; the format is secondary. Don't manufacture a "hot take" the source doesn't support.
+
+## Depth
+- quick: one LinkedIn post.
+- standard: LinkedIn + X versions.
+- deep: + a carousel/thread outline and a "reuse later" note.

--- a/skills/example-skill/SKILL.md
+++ b/skills/example-skill/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: example-skill
+description: A template skill. Replace it with a task you repeat. Trigger only when the user explicitly asks to run the example skill.
+---
+
+# Example Skill (template)
+
+A skill is a reusable unit of work Claude runs when your request matches its `description`. The description *is* the trigger — keep it specific, or it fires at the wrong time (or never).
+
+This one does nothing on purpose. Swap it for your own. A good skill:
+
+- does one job well,
+- reads from `ops/` (or `demo/`) instead of asking for context it could find,
+- ends by writing its result somewhere durable — a file, a log.
+
+See `skills/status-update/` and `skills/triage/` for two worked examples.

--- a/skills/follow-up/SKILL.md
+++ b/skills/follow-up/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: follow-up
+description: Debrief a meeting and draft the follow-up. Trigger when the user asks to debrief a call, follow up, or "what do I send after that meeting".
+---
+
+# Debrief & Follow-up
+
+From a meeting note (point me at one in `ops/` or `demo/meetings/`) or a pasted recap:
+
+1. **Debrief (for you):** decisions made, commitments — yours and theirs — and any new risk or signal. Offer to append it to `ops/daily-log.md`.
+2. **Follow-up (for them):** lead with the commitment you made or the decision they owe — not "just checking in". One clear next step with a date. Keep it short; a follow-up that needs scrolling doesn't get read.
+
+Don't invent facts the note doesn't contain. Bring your own voice; this drafts the structure.
+
+## Depth
+- quick: the follow-up message only.
+- standard: debrief notes + the message + a subject line.
+- deep: + a second nudge for if they go quiet, with the date to send it.

--- a/skills/lead-qualify/SKILL.md
+++ b/skills/lead-qualify/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: lead-qualify
+description: Score a lead or opportunity against an ideal-customer-profile fit check. Trigger when the user pastes a lead/company and asks "is this a fit", "should I pursue", or to qualify/score a lead against the ICP.
+---
+
+# Lead Qualify (ICP check)
+
+Score a lead against fit, not hype. Default criteria — edit them to your own ICP in `ops/icp.md` if you keep one:
+
+- Do they have the problem you solve, today (not someday)?
+- Can they buy — budget, and someone with authority?
+- Is there a reason to act now?
+- Do you have a way in — a warm path or a real signal?
+
+Output: a 0–4 fit count, the single biggest gap, and a call: **pursue / nurture / pass.** A clear "pass" is worth more than a hopeful "maybe". Read `ops/icp.md` first if it exists; don't invent facts about the company you weren't given.
+
+## Depth
+- quick: pursue / nurture / pass + one reason.
+- standard: the full scoring above.
+- deep: + the disqualifiers, and what would have to change to requalify.

--- a/skills/marketing-feedback/SKILL.md
+++ b/skills/marketing-feedback/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: marketing-feedback
+description: Turn what sales hears in the field into marketing actions. Trigger when a meeting note or call recap surfaces a recurring objection, a competitor mention, the buyer's own language, a missing proof point, or a win/loss reason — or when the user says "log this for marketing", "what should marketing know", or "field intel".
+---
+
+# Marketing Feedback
+
+The loop that keeps sales and marketing as one system: field intelligence flows from sales back to marketing on a cadence, instead of dying inside a meeting note. This is mechanism #5 from [`docs/why-align.md`](../../docs/why-align.md) — made concrete as a tagged line in a shared log.
+
+From a source — a note in `ops/daily-log.md`, a file in `demo/meetings/`, a call recap, a deal update:
+
+1. **Scan for the five signal types:**
+   - **Recurring objection** — the same pushback in 3+ conversations.
+   - **Competitor mention** — who showed up, and how the buyer described them.
+   - **Buyer language** — the words they actually used (use them in content; don't translate them into your own).
+   - **Missing proof** — evidence they asked for that doesn't exist yet.
+   - **Win/loss reason** — the real one, not the polite one.
+2. **Log each as a tagged line** in the daily log, so marketing can act on it without a meeting:
+   - `MARKETING-ACTION: [signal] — [the content or proof that would answer it]`
+   - `MARKETING-ACTION-URGENT:` when a live deal was affected.
+   - `MARKETING-STRATEGIC:` when it signals a positioning or new-segment shift.
+3. **Don't invent signals.** One offhand comment isn't a pattern — tag it only when it recurs across deals or clearly cost one. A log full of false patterns is worse than an empty one.
+
+The tag *is* the hand-off. One file, both functions read it — that's the loop, version-controlled, with a diff and a history. Marketing's job is to clear the `MARKETING-ACTION` lines; sales' job is to keep them honest and current.
+
+## Depth
+- quick: scan one note, emit any `MARKETING-ACTION` lines.
+- standard: the full five-signal scan across recent notes, tagged and ranked by urgency.
+- deep: + a one-line content brief for the top signal (who it's for, the claim to make, the proof to find).

--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: meeting-prep
+description: Build a pre-meeting briefing — who's in the room, what they care about, your goal, and the questions to ask. Trigger when the user asks to prep for a meeting or call, "what should I know before", or names an upcoming meeting.
+---
+
+# Meeting Prep (pre-meeting briefing)
+
+Before a meeting, build a one-screen brief:
+
+1. **Who's in the room** and what each likely cares about.
+2. **Where this sits** — pull from `ops/pipeline.md` and any prior notes: last contact, open threads, commitments outstanding.
+3. **Your one goal** for the meeting, and the single decision you want out of it.
+4. **Three questions to ask** — open, not leading.
+5. **The one risk or objection** to be ready for.
+
+Pull context from `ops/` and the relevant meeting notes; don't invent attendees or history you weren't given.
+
+## Depth
+- quick: the goal + three questions.
+- standard: the full brief above.
+- deep: + a likely-objections list and a fallback ask if the main one stalls.

--- a/skills/onboarding-handoff/SKILL.md
+++ b/skills/onboarding-handoff/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: onboarding-handoff
+description: Run the Won→onboarding handoff — the seam most teams drop. Trigger when a deal is marked won/closed-won, when the user says "we won X", "hand this off to onboarding", "kick off the new customer", or "onboarding checklist".
+---
+
+# Onboarding Handoff (Won → onboarding)
+
+The handoff most teams never define: a signed deal drops silently into a customer-success void, the value the buyer was sold gets lost, and the renewal clock starts late. This is handoff **H3** in [`docs/operating-model.md`](../../docs/operating-model.md) — made concrete as a 48-hour checklist that turns a won deal into the first row of the account book.
+
+From the won deal (point me at the row in `ops/pipeline.md`, or paste the deal context):
+
+1. **Carry the value hypothesis forward.** Write down, in one line, what the customer bought this to do — in their words, from discovery. This becomes the value hypothesis in `ops/customers.md`, and the thing every adoption check is measured against. Lose it here and onboarding optimizes for activity, not value.
+2. **Set the date markers.** Record the renewal date and note the **day-60** renewal-motion trigger (not day-85). Set a first-expansion check date too — the moment to look for a second team or use case.
+3. **Identify the power user / champion.** Name who will actually use it and who sponsors it internally. A single-threaded account is a churn risk before it's even live — if there's only one name, that's the first gap to close.
+4. **Write the first adoption milestone.** One concrete, dated outcome that proves value is landing (the first workflow live, the first cross-system answer, the first report shipped). Vague onboarding has no finish line.
+5. **Open the row.** Create the account in `ops/customers.md` at stage **Onboarding**, with the value hypothesis, the first adoption signal to watch, the renewal date, an owner, and the next step. Offer to log the handoff in `ops/daily-log.md`.
+
+Don't invent commitments the deal didn't contain. Bring your own onboarding playbook; this carries the deal's context across the seam so nothing drops.
+
+## Depth
+- quick: open the `ops/customers.md` row with value hypothesis, renewal date, and owner.
+- standard: the full 48-hour checklist above.
+- deep: + a single-threading risk read and the first two adoption milestones with dates.

--- a/skills/product-signal/SKILL.md
+++ b/skills/product-signal/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: product-signal
+description: Route post-sale and field signals into product's roadmap queue, and write the buyer-facing line for anything shipped. Trigger when the user says "what should product hear", "triage the roadmap signals", "route this to product", "feature request", or "what does this feature mean for the buyer".
+---
+
+# Product Signal
+
+The product function's place in the loop. Marketing has `marketing-feedback`; CS has `account-health`; this is product's. It pulls the signals that should shape what gets built out of the shared log into product's own triage queue, and — for anything shipped — writes the one-line "what this means for the buyer" so a feature doesn't land silently. This closes handoffs **H4** (CS→product) and **H5** (product→GTM) in [`docs/operating-model.md`](../../docs/operating-model.md).
+
+From the shared feedback log (`demo/feedback-log.md`, or your own) and `ops/customers.md`:
+
+1. **Pull the product-shaped signals.** Three kinds belong on the roadmap, not in a meeting note:
+   - `RETENTION-RISK` lines that are really a product gap — adoption friction or a missing capability, not a CS task.
+   - `FEATURE-REQUEST` items that block an adoption or an expansion (the ones tied to a renewal or a second team).
+   - Win/loss reasons that are about the *product*, not the deal — what we couldn't do that cost us, or won us, the deal.
+2. **Route each into `ops/roadmap-signals.md`.** One row per signal: the source, the type, the account or pattern it's tied to, where it's routed, and a status (New → Routed → Shipped). This is product's working surface — distinct from the raw log it's pulled from.
+3. **Wait for the pattern on anything ambiguous.** A single request isn't a roadmap item; a request that recurs across accounts, or one blocking a real renewal, is. Don't route noise.
+4. **Close the loop on anything shipped.** For each item that ships, write the one-line buyer-facing translation in the last column: *what can the customer now do that they couldn't before* — in their language, not the release note's. Hand that line to GTM (it's what `marketing-feedback`'s readers and the deal follow-ups need). No feature ships without it — the antidote to building things no one adopts.
+
+Don't promise a roadmap; this routes the signal and frames the outcome. The build decision is yours.
+
+## Depth
+- quick: pull the product-shaped signals from the log into `ops/roadmap-signals.md`.
+- standard: the full triage above — routed, status-tagged, patterns separated from noise.
+- deep: + the buyer-facing line for each shipped item, ready to hand to GTM.

--- a/skills/retention-feedback/SKILL.md
+++ b/skills/retention-feedback/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: retention-feedback
+description: Turn what customer success hears after the sale into product and retention actions. Trigger when an onboarding note, QBR, support thread, or usage review surfaces adoption friction, a churn-risk signal, a feature request that blocks expansion, or a customer who's ready to grow — or when the user says "log this for product", "retention risk", "what's the churn signal", or "post-sale feedback".
+---
+
+# Retention Feedback
+
+The loop that keeps the *post-sale* half of the motion connected to product — the half the funnel forgets. Sales→marketing is the loop everyone can see; this is its mirror on the right side of the bowtie. Field intelligence from onboarding, adoption, and renewal flows back to product and CS on a cadence, instead of dying in a QBR. This is the four-function version of the alignment thesis in [`docs/why-align.md`](../../docs/why-align.md) — made concrete as a tagged line in the same shared log the `marketing-feedback` skill writes to.
+
+From a source — an onboarding note, a usage review, a support thread, a renewal call, a deal update:
+
+1. **Scan for the four signal types:**
+   - **Adoption friction** — where customers stall between signing and getting value (the workflow they never turned on, the setup step that blocks them).
+   - **Churn risk** — the real leading indicator: usage trending down, a champion gone quiet, a single-threaded account after a reorg.
+   - **Expansion blocker / signal** — a missing feature that's holding back a renewal or a second department; or, the opposite, a customer asking for more unprompted.
+   - **Renewal-loss reason** — the real one, logged, not remembered (people misdiagnose why accounts leave as often as why deals are lost).
+2. **Log each as a tagged line** in the same daily log / feedback log marketing uses, so product and CS can act without a meeting:
+   - `RETENTION-RISK: [account] — [the adoption/churn/blocker signal] → [product or CS action]`
+   - `EXPANSION-SIGNAL:` when a healthy account is ready to grow (hand to sales with the CS context attached).
+3. **Route, don't dump.** A feature request that blocks adoption goes to the *roadmap*, not the backlog void. A churn signal triggers the renewal motion early — day 60, not day 85. Don't tag every quiet week as a risk; tag it when usage, the champion, or the value story is actually slipping.
+
+The tag *is* the hand-off. One file — the same one marketing reads — now carries both loops, so a post-sale signal can't quietly die any more than a field objection can. Product's job is to clear the `RETENTION-RISK` lines that are really roadmap; CS's job is to keep them honest and act on the renewal clock.
+
+## Depth
+- quick: scan one note, emit any `RETENTION-RISK` / `EXPANSION-SIGNAL` lines.
+- standard: the full four-signal scan across recent post-sale notes, tagged and routed to product vs. CS.
+- deep: + a one-line "what this means for the buyer" for the top signal, and the renewal-clock implication (when the motion should start).

--- a/skills/status-update/SKILL.md
+++ b/skills/status-update/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: status-update
+description: Draft a short status update from recent daily-log entries. Trigger when the user asks for a status update, a weekly update, or "what should I tell my team / manager / board".
+---
+
+# Status Update
+
+Draft a short update a busy stakeholder would actually read, from `ops/daily-log.md`:
+
+1. Read the last five to seven entries.
+2. Write three bullets: what moved, what's blocked, what's next.
+3. Keep it under 120 words. Lead with the outcome, not the activity. No filler.
+
+Offer to save it to `ops/updates/<date>.md`.

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: triage
+description: Triage a list of incoming items into do-now / schedule / delegate / drop. Trigger when the user pastes a list and asks to triage, prioritize, or "what should I do first".
+---
+
+# Triage
+
+Given a list the user pastes (or a file they point to):
+
+1. Sort each item into one of four buckets: **Do now · Schedule · Delegate · Drop.**
+2. Within "Do now", order by leverage, not urgency.
+3. Flag anything that's clearly been sitting too long.
+
+Return the four buckets, shortest first. Don't pad, and don't keep things in "Do now" to be polite.


### PR DESCRIPTION
## Summary

Populates the repo with the four-function go-to-market starter (marketing, sales, product, retention) from LangOptima-General's `claude-code-ops-starter`, ready for the CCCL #6 giveaway (Tue 26 May). Replaces the 116-byte placeholder README.

## What's included (44 files, 1 placeholder line removed)

- `.claude/` — 5 ritual commands, 5 guardrail hooks (executable), `settings.json`
- `ops/` + `demo/` — operating playbooks; demo data uses fictional companies only
- `docs/` — operating model, methodology, why-align
- `skills/` — 13 skills across the four growth functions
- `README`, `CONTRIBUTING`, `.gitignore` (excludes `settings.local.json` / `.mcp.json` / `.env*`)

## Pre-publish safety (handoff §4) — done

- [x] No real data — all six demo companies fictional (Thornbury, Rheinkraft, Cascadia, Northwind, Halden, Meridian)
- [x] No secrets — `settings.local.json` excluded; secret/token scan clean
- [x] LICENSE (MIT) + CONTRIBUTING.md at root
- [x] No `sales-os` / LangOptima-internal positioning; only the intended `langoptima.com/growth` author CTA in the README
- [x] No leak of LangOptima-General internal config (no `.claude/rules/`; no CGO pricing, Prasad, Notion/Lightfield IDs)

## Still to verify (optional, pre-giveaway)

- [ ] `/demo-briefing` runs cleanly on a fresh clone; README renders on GitHub
- [ ] Secret-guard install line works: `ln -s ../../.claude/hooks/pre-commit-guard.sh .git/hooks/pre-commit`

## After merge

The repo is currently **private**. Flip it to public (Settings → General → Change visibility) before the giveaway, or attendees cloning `github.com/etrebels/claude-code-growth-os` will hit a 404.

https://claude.ai/code/session_01Lx9JS7jY3T1URbfZsGZ9JE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx9JS7jY3T1URbfZsGZ9JE)_