### PR TITLE
Launch: bring the full Growth OS kit to main

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+edwin.trebels@langoptima.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,7 @@ This is a starter — a clean, generic scaffold people fork and fill. Contributi
 - Run `/demo-briefing` and confirm it still works.
 - Install and trip the commit guard: `ln -s ../../.claude/hooks/pre-commit-guard.sh .git/hooks/pre-commit`, then try committing a fake key — it should block.
 - Keep the diff focused; one idea per PR.
+
+## Code of conduct
+
+By taking part, you agree to uphold our [Code of Conduct](CODE_OF_CONDUCT.md) — be kind, assume good intent, keep it professional.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This repo is the scaffolding: opinionated hooks, daily rituals, a set of go-to-m
 
 ## See it run in 30 seconds
 
+<!-- DEMO GIF: record `/demo-briefing` (asciinema or terminalizer), save to docs/assets/demo.gif,
+     then replace this comment with:  ![Claude Code Growth OS — morning briefing on demo data](docs/assets/demo.gif) -->
+
 Clone, open in Claude Code, and run `/demo-briefing`. It runs the whole morning ritual against the fictional sample data in `demo/`:
 
 ```
@@ -111,6 +114,16 @@ The `.claude/skills/` and `.claude/commands/` are plain markdown on the Agent Sk
 ## What's deliberately not here
 
 No real playbooks, positioning, pricing, or data. That's the point: the structure is reproducible; the judgment you put inside it is the part that's yours. Fill one drawer this week.
+
+## What's free vs. what's paid
+
+This is **open core**. The chassis is free and MIT-licensed; the part that took twenty-one years isn't in the box.
+
+| Free — this repo (MIT) | Paid — built & run for you |
+|---|---|
+| The chassis: hooks, daily rituals, and go-to-market skill templates across all four functions, plus a 30-second runnable demo. Bring your own playbooks. | Your *populated* operating system — real playbooks, positioning, pricing, ICP — plus the wider automation layer (n8n: vendor management, ICP checks, pre- and post-meeting briefings and follow-ups) and Blackbird.io multilingual content. Built and run for you, or run by a growth operator who works this way. |
+
+The repo is the skeleton; the judgment you put inside it is the product → **[langoptima.com/growth](https://langoptima.com/growth)**.
 
 ## Who's behind this
 

--- a/docs/launch-scrub-checklist.md
+++ b/docs/launch-scrub-checklist.md
@@ -1,0 +1,77 @@
+# Pre-Launch Scrub Checklist
+
+Run this before you flip a repo — this one, or a fork you've filled with your own
+content — to **public**. It catches the two things that actually hurt: secrets,
+and other people's data. Every item is a copy-paste command plus a yes/no.
+
+> **Why it matters.** This kit is built to be filled with *your* playbooks,
+> pipeline, and customer notes. The empty starter is safe to publish; a populated
+> fork is **not** until you've checked it. The `demo/` folder is fictional on
+> purpose — present and share from that.
+
+## 1. Secrets — working tree *and* full history
+
+A secret deleted in a later commit still lives in history. Scan both.
+
+```bash
+# High-confidence key formats across every commit
+git log -p --all | grep -niE \
+  'sk-ant-[a-z0-9]|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|github_pat_|AIza[0-9A-Za-z_-]{35}|xox[baprs]-|-----BEGIN.*PRIVATE KEY|eyJ[A-Za-z0-9_-]{10,}\.eyJ'
+```
+
+- [ ] No output. (The only acceptable hit is the pattern list inside
+  `.claude/hooks/pre-commit-guard.sh` — that's the guard describing itself.)
+
+```bash
+# Generic credential words assigned a value
+git log -p --all | grep -niE '(password|api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]+' \
+  | grep -viE 'example|placeholder|your[_-]|<|settings.local|\.env'
+```
+
+- [ ] Nothing real — only examples and placeholders.
+
+## 2. Local / secret config is gitignored and untracked
+
+- [ ] `.mcp.json`, `.claude/settings.local.json`, and `.env*` are listed in
+  `.gitignore`.
+- [ ] None are tracked:
+  `git ls-files | grep -E '\.env|settings\.local\.json|^\.mcp\.json$'` returns
+  nothing.
+- [ ] Only the committed `*.example` versions exist.
+
+## 3. Other people's data (the legal one)
+
+Real prospect / customer names, deals, and meeting notes are third-party personal
+data. Keep them out of a public repo.
+
+```bash
+# Emails in history — a commit-author email is fine; emails in file content are not
+git log -p --all | grep -oiE '[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}' | sort -u
+
+# Phone-like numbers
+git log -p --all | grep -oiE '\+?[0-9]{1,3}[ -]?\(?[0-9]{2,4}\)?[ -][0-9]{3,4}[ -][0-9]{3,4}' | sort -u
+```
+
+- [ ] `ops/` files are empty templates, or filled only with data you're willing
+  to publish.
+- [ ] `demo/` contains only fictional names (or you've deleted it).
+- [ ] No real account or contact names in any tracked file.
+- [ ] (Optional, privacy) Decide whether your commit-author email should be your
+  real address or a GitHub `noreply` one.
+
+## 4. The repo is actually launch-shaped
+
+- [ ] `LICENSE` present and correct.
+- [ ] `README` renders, and its call-to-action link is right.
+- [ ] The **default branch** (`main`) holds the real content, not a stub —
+  `git ls-tree -r main --name-only | wc -l` looks right.
+- [ ] Visibility is **Public** — do this **last**, once everything above passes.
+
+## 5. Leave the guard armed
+
+```bash
+ln -s ../../.claude/hooks/pre-commit-guard.sh .git/hooks/pre-commit
+```
+
+- [ ] Commit guard installed so a future secret can't slip in. Test it: try to
+  commit a fake key — it should block.


### PR DESCRIPTION
## What this does

Brings the complete **Claude Code Growth OS** onto `main` so the public default branch isn't an empty stub at launch. `main` currently has 2 files (LICENSE + a one-line README stub); this PR makes it the full **49-file** kit.

## What's inside
- **README** — value prop, 30-second demo, what's inside, portability, and an open-core "what's free vs. what's paid" section
- **`.claude/`** — 5 hooks, 5 ritual commands, and 13 go-to-market skill templates across all four functions (marketing, sales, product, retention)
- **`demo/`** — a fictional pipeline + customer book so the loop runs (and presents) safely
- **`docs/`** — operating model, methodology, why-align, and a pre-launch scrub checklist
- **Community health** — LICENSE (MIT), CONTRIBUTING, SECURITY, CODE_OF_CONDUCT

## Latest commit adds
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- `docs/launch-scrub-checklist.md` — reusable pre-publish scan
- README "What's free vs. what's paid" section + a demo-gif placeholder
- CONTRIBUTING link to the Code of Conduct

## Pre-launch scrub: clean
- No secrets in the working tree **or** full git history (the only match is the commit-guard's own regex describing itself)
- No real customer/contact data — `demo/` is fictional and labeled as such; `ops/` files are empty templates
- Local/secret config (`.mcp.json`, `.claude/settings.local.json`, `.env*`) is gitignored and untracked

## After merging
1. **Flip the repository to Public** (Settings → General → Danger Zone → Change visibility). Do this last.
2. *(Optional)* drop a demo gif at `docs/assets/demo.gif`, set the repo description + homepage to `langoptima.com/growth`, and enable Discussions for community Q&A.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gw5Abysp6CZddsniga6vp)_