### PR TITLE
Add issue templates (completes Community Standards)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something in the kit doesn't work — a hook, command, skill, or the demo
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please keep the report **generic** — no real company names, playbooks, or credentials. Reproduce against the fictional `demo/` data where you can.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead?
+      placeholder: Running /demo-briefing errored with...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the repo in Claude Code
+        2. Run `/...`
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part?
+      options:
+        - Hook (.claude/hooks)
+        - Command / ritual (.claude/commands)
+        - Skill (.claude/skills)
+        - Demo (demo/)
+        - Docs
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS and Claude Code version (run `claude --version`).
+      placeholder: macOS 15.3, Claude Code 1.x
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: This report contains no secrets or real customer/contact data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & show-and-tell
+    url: https://github.com/etrebels/claude-code-growth-os/discussions
+    about: Ask how to use the kit, or share how you've made it yours. (Enable Discussions in Settings.)
+  - name: Report a security issue
+    url: https://github.com/etrebels/claude-code-growth-os/security/policy
+    about: Please report vulnerabilities privately — not as a public issue.
+  - name: Want it built & run for you?
+    url: https://langoptima.com/growth
+    about: The populated, done-for-you version and growth-operator service.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Idea / new skill or ritual
+description: Suggest a new hook, ritual command, skill template, or docs improvement
+title: "[idea]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ideas that keep the starter **generic and reusable** are the best fit — see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md). If it only works with your private content, it belongs in your fork.
+  - type: textarea
+    id: idea
+    attributes:
+      label: What's the idea?
+      description: Describe the hook, ritual, skill, or doc — and the recurring job it does.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area?
+      options:
+        - Marketing / Demand
+        - Sales
+        - Product
+        - Retention
+        - Cross-cutting (status, triage)
+        - Hook / guardrail
+        - Ritual command
+        - Docs / example
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does it solve?
+      description: What's painful today, and how does this help?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: This generalizes beyond one company — no real data required to use it.
+          required: true


### PR DESCRIPTION
Adds issue templates so "New issue" isn't a blank box — and completes GitHub's **Community Standards** checklist (8/8).

- **`bug_report.yml`** — for a hook/command/skill/demo that doesn't work, with an area dropdown, environment field, and a *no secrets / no real data* check.
- **`feature_request.yml`** — for a new hook, ritual, skill, or docs idea, with a "this generalizes beyond one company" check (mirrors CONTRIBUTING's one rule).
- **`config.yml`** — keeps blank issues enabled and adds contact links: Questions → Discussions, security → the private policy, and a "built & run for you" → `langoptima.com/growth`.

> Note: the Discussions link works once you enable **Discussions** in Settings (recommended). Issue templates render from the repo's default branch, so they go live as soon as this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gw5Abysp6CZddsniga6vp)_