### PR TITLE
Add CHANGELOG and editorial polish for v0.1.0

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -8,7 +8,7 @@ description: Triage a list of incoming items into do-now / schedule / delegate /
 Given a list the user pastes (or a file they point to):
 
 1. Sort each item into one of four buckets: **Do now · Schedule · Delegate · Drop.**
-2. Within "Do now", order by leverage, not urgency.
+2. Within "Do now", order by impact, not urgency.
 3. Flag anything that's clearly been sitting too long.
 
 Return the four buckets, shortest first. Don't pad, and don't keep things in "Do now" to be polite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-25
+
+First public release — the open-core scaffold for running your whole
+go-to-market inside Claude Code. Structure is included; the judgment you put
+inside it is yours to add.
+
+### Added
+
+- **Hooks** (`.claude/hooks/`) — five guardrails: session-start context,
+  state re-injection across compaction, a commit secret-guard, sensitive-file
+  write protection, and an end-of-day nudge. Pure bash, no dependencies.
+- **Rituals** (`.claude/commands/`) — `/morning-briefing`, `/midday-checkin`,
+  `/end-of-day`, `/weekly-review`, and a `/demo-briefing` that runs the whole
+  loop on fictional sample data.
+- **Skills** (`.claude/skills/`) — go-to-market skill templates across all four
+  functions (marketing, sales, product, retention), plus cross-cutting helpers
+  and an example template to copy.
+- **Operating surfaces** (`ops/`) — plain-text playbook templates: priorities,
+  pipeline, customers, daily log, and roadmap signals. Yours to fill.
+- **Demo** (`demo/`) — a fully fictional pipeline, customer book, meeting notes,
+  and feedback log, so the whole motion runs in about 30 seconds and is safe to
+  present from.
+- **Docs** — the operating model (the bowtie, the six handoffs, net revenue
+  retention as the one number), the methodology, a sourced argument for running
+  the four functions as one system, and a pre-launch scrub checklist.
+- **Project hygiene** — README with a demo animation, MIT license, contributing
+  guide, security policy, code of conduct, and issue + pull-request templates.
+
+[0.1.0]: https://github.com/etrebels/claude-code-growth-os/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 ![Built for Claude Code](https://img.shields.io/badge/built%20for-Claude%20Code-d97757)
 ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 
-Most people ask Claude Code to write code. You can also run your go-to-market in it: let it read your plain-text playbooks, run your daily rituals — the morning briefing, follow-ups, lead qualification, content — and reach your tools, so the whole motion runs from one place. Because everything is markdown in git, your sales & marketing system gets a diff, a history, and a blame view, and it stops living in your head.
+Most people ask Claude Code to write code. You can also run your go-to-market in it: let it read your plain-text playbooks, run your daily rituals (the morning briefing, follow-ups, lead qualification, content) and reach your tools, so the whole motion runs from one place. Because everything is markdown in git, your sales & marketing system gets a diff, a history, and a blame view, and it stops living in your head.
 
-Most sales & marketing skill packs just generate copy. This runs the operating day around it — qualify, prep, follow up, post — and keeps it all in git.
+Most sales & marketing skill packs just generate copy. This runs the operating day around it (qualify, prep, follow up, post) and keeps it all in git.
 
 This repo is the scaffolding: opinionated hooks, daily rituals, a set of go-to-market skill templates spanning all four functions, and a worked example you can run in 30 seconds. **Bring your own playbooks — the structure is here.**
 
@@ -57,7 +57,7 @@ Nothing there is real — delete `demo/` whenever you like.
 | `.claude/skills/` | Skill templates grouped by the four growth functions (see below) — so the balance across marketing, sales, product, and retention is visible, not acquisition-only |
 | `ops/` | Your plain-text playbooks — `priorities.md`, `daily-log.md`, `pipeline.md` (left side), `customers.md` and `roadmap-signals.md` (right side). Start here. |
 | `demo/` | A fictional pipeline *and* customer book so you can see the whole motion work (and present from it safely) |
-| `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (NRR), and the three shared definitions |
+| `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (net revenue retention), and the three shared definitions |
 | `docs/methodology.md` | The idea in full: Claude Code as an operating environment |
 | `docs/why-align.md` | The one-page argument: why your whole go-to-market (marketing, sales, product, retention) runs as one system (with sources) |
 
@@ -77,7 +77,7 @@ One loop, all plain text in git:
 
 1. **Open a session** → the SessionStart hook surfaces today's priorities.
 2. **`/morning-briefing`** reads your priorities, yesterday's log, and your pipeline → today's top three.
-3. **Through the day**, the skills work on your own data — on both sides of the bowtie. *Left side:* `lead-qualify` a new opportunity, `meeting-prep` before a call, `follow-up` after it, `cold-outreach` to a prospect, `content-repurpose` a win into posts, `marketing-feedback` to turn a recurring objection into a note marketing acts on. *Right side:* `onboarding-handoff` when a deal is won (carry the value hypothesis across the seam), `account-health` to score adoption and start the renewal motion at day 60, `product-signal` to route retention and field signals to the roadmap, and `retention-feedback` to turn an adoption slip into a signal product acts on.
+3. **Through the day**, the skills work on your own data, on both sides of the bowtie. *Left side:* `lead-qualify` a new opportunity, `meeting-prep` before a call, `follow-up` after it, `cold-outreach` to a prospect, `content-repurpose` a win into posts, `marketing-feedback` to turn a recurring objection into a note marketing acts on. *Right side:* `onboarding-handoff` when a deal is won (carry the value hypothesis across the seam), `account-health` to score adoption and start the renewal motion at day 60, `product-signal` to route retention and field signals to the roadmap, and `retention-feedback` to turn an adoption slip into a signal product acts on.
 4. **`/end-of-day`** logs what shipped and sets tomorrow; **`/weekly-review`** finds the patterns across both sides — renewals due, accounts at risk, expansion candidates, and the top roadmap signals.
 5. **The hooks hold it together** — your state survives a long session (`pre-compact`), and nothing secret slips into a commit (`pre-commit-guard`).
 
@@ -116,7 +116,7 @@ No real playbooks, positioning, pricing, or data. That's the point: the structur
 
 ## What's free vs. what's paid
 
-This is **open core**. The chassis is free and MIT-licensed; the part that took twenty-one years isn't in the box.
+This is **open core**. The chassis is free and MIT-licensed; the part that took twenty-two years isn't in the box.
 
 | Free — this repo (MIT) | Paid — built & run for you |
 |---|---|
@@ -126,7 +126,7 @@ The repo is the skeleton; the judgment you put inside it is the product → **[l
 
 ## Who's behind this
 
-I'm Edwin Trebels — I run our company's entire go-to-market on a setup like this, and help clients run theirs. This repo is the open skeleton. The full version adds the wider automation layer — n8n handling vendor management, ICP checks, pre-meeting briefings, post-meeting debriefs and follow-ups, and the assistant that keeps the day straight; Blackbird.io for multilingual content — plus the judgment that fills the empty drawers. That part took twenty-two years and doesn't come in a folder.
+I'm Edwin Trebels — I run our company's entire go-to-market on a setup like this, and help clients run theirs. This repo is the open skeleton. The full version adds the wider automation layer (n8n handling vendor management, ICP checks, pre-meeting briefings, post-meeting debriefs and follow-ups, and the assistant that keeps the day straight; Blackbird.io for multilingual content), plus the judgment that fills the empty drawers. That part took twenty-two years and doesn't come in a folder.
 
 Want it built and run for you, or a growth operator who works this way? That's what I do: [langoptima.com](https://langoptima.com). The thinking behind the kit is in [`docs/methodology.md`](docs/methodology.md).
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -29,7 +29,7 @@ A motion is only as strong as its handoffs. Each one has a **trigger**, an **own
 |---|---|---|---|---|
 | **H1** | Marketing → Sales | A lead clears the MQL→SQL bar | Marketing | A qualified lead in `ops/pipeline.md` |
 | **H2** | Sales → Marketing | Sales hears a recurring objection, competitor, missing proof, or win/loss reason | Sales | A `MARKETING-ACTION` line in the feedback log (`marketing-feedback`) |
-| **H3** | Won → Onboarding | A deal is marked won | Sales → CS | The first `ops/customers.md` row, with the value hypothesis carried forward (`onboarding-handoff`) |
+| **H3** | Won → Onboarding | A deal is marked won | Sales → customer success (CS) | The first `ops/customers.md` row, with the value hypothesis carried forward (`onboarding-handoff`) |
 | **H4** | CS → Product | Adoption friction, a churn reason, or a request blocking adoption/expansion | CS | A routed item in `ops/roadmap-signals.md` (`product-signal`) |
 | **H5** | Product → GTM | A capability ships | Product | The one-line "what this means for the buyer" in `ops/roadmap-signals.md`, handed to sales and marketing (`product-signal`) |
 | **H6** | CS → Marketing | A customer reaches a clear outcome | CS | A reference / proof point — the customer's own words for the value they got |


### PR DESCRIPTION
Carries the pieces PR #6's merge didn't land (only the GIF commit made it onto `main`), rebased over your `/features/growth` link fixes so nothing of yours is lost.

- **`CHANGELOG.md`** — Keep a Changelog format, SemVer, documenting the v0.1.0 release contents.
- **README** — expand net revenue retention on first use, thin the clustered em-dashes (the double-dash parentheticals; the emphatic ones stay), and fix a year inconsistency (one spot said "twenty-one", the other "twenty-two" — now both twenty-two).
- **`operating-model.md`** — expand "customer success (CS)" on first use.
- **`triage` skill** — swap one AI-signature word ("leverage") for a plain verb.

Once this is on `main`, `v0.1.0` gets tagged.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gw5Abysp6CZddsniga6vp)_