### PR TITLE
Implement open issues: secret patterns, shellcheck CI, first-ritual guide

### DIFF
--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -12,7 +12,26 @@ set -euo pipefail
 staged="$(git diff --cached --name-only --diff-filter=ACM || true)"
 [ -z "$staged" ] && exit 0
 
-patterns='(AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|sk-[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]+|ghp_[A-Za-z0-9]{36}|(password|api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]+)'
+# Credential formats we block (matched case-insensitively). Add new ones here:
+#   AWS access key id    — AKIA + 16 chars
+#   GitHub tokens        — ghp_/gho_/ghs_/ghr_/ghu_ + 36 chars, and fine-grained github_pat_…
+#   Slack tokens         — xoxb-/xoxa-/xoxp-/xoxr-/xoxs-…
+#   Google API keys      — AIza + 35 chars
+#   Stripe live keys     — sk_live_… / rk_live_…
+#   OpenAI-style keys    — sk- + 20+ chars
+#   PEM private keys     — -----BEGIN … PRIVATE KEY-----
+#   Generic assignments  — password / api_key / secret / token = <value>
+patterns='('
+patterns+='AKIA[0-9A-Z]{16}'                                                              # AWS access key id
+patterns+='|gh[opsru]_[A-Za-z0-9]{36}'                                                    # GitHub token (ghp_/gho_/ghs_/ghr_/ghu_)
+patterns+='|github_pat_[A-Za-z0-9_]{22,}'                                                 # GitHub fine-grained PAT
+patterns+='|xox[baprs]-[A-Za-z0-9-]+'                                                     # Slack token
+patterns+='|AIza[0-9A-Za-z_-]{35}'                                                        # Google API key
+patterns+='|(sk|rk)_live_[0-9A-Za-z]{24,}'                                                # Stripe live key
+patterns+='|sk-[A-Za-z0-9]{20,}'                                                          # OpenAI-style key
+patterns+='|-----BEGIN [A-Z ]*PRIVATE KEY-----'                                           # PEM private key
+patterns+='|(password|api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]+' # generic assignment
+patterns+=')'
 
 hits="$(git diff --cached -U0 | grep -nEi "$patterns" || true)"
 if [ -n "$hits" ]; then

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+name: shellcheck
+
+# The hooks in .claude/hooks/ are the repo's guardrails. Lint them on every
+# change so a shell mistake can't slip in. Scoped to the hook scripts only.
+on:
+  push:
+    paths:
+      - ".claude/hooks/**"
+      - ".github/workflows/shellcheck.yml"
+  pull_request:
+    paths:
+      - ".claude/hooks/**"
+      - ".github/workflows/shellcheck.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint .claude/hooks/*.sh
+        run: |
+          shellcheck --version
+          shellcheck .claude/hooks/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **First-ritual guide** (`docs/first-ritual.md`) — a 5-minute walkthrough that
+  copies `/midday-checkin` into your own ritual, linked from the README. (#10)
+- **Shellcheck CI** (`.github/workflows/shellcheck.yml`) — lints the bash hooks
+  in `.claude/hooks/` on every push and pull request. (#9)
+
+### Changed
+
+- **Commit secret-guard** (`.claude/hooks/pre-commit-guard.sh`) — broadened to
+  catch GitHub fine-grained PATs and OAuth/server tokens, Google API keys, and
+  Stripe live keys, with the covered formats documented inline. (#8)
+
 ## [0.1.0] — 2026-05-25
 
 First public release — the open-core scaffold for running your whole

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All pure bash (one uses `python3` to read a payload). No API keys, no MCP — it
 ## Make it yours
 
 - **`ops/`** — one file per area. Don't port your whole life on day one; pick the ritual you dread most and make it real.
-- **`.claude/commands/`** — a ritual is just a markdown prompt. Copy one and tweak it.
+- **`.claude/commands/`** — a ritual is just a markdown prompt. Copy one and tweak it — [write your first in 5 minutes](docs/first-ritual.md).
 - **`.claude/skills/`** — a repeatable job, triggered by its `description`. Copy one of the included skills as a pattern.
 - **Connect your tools** — copy `.mcp.json.example` → `.mcp.json` (gitignored) to add MCP servers (calendar, notes, issue tracker, CRM), and put any keys in `.claude/settings.local.json` (copy `.claude/settings.local.example.json`). Your commands and skills can then reach them.
 

--- a/docs/first-ritual.md
+++ b/docs/first-ritual.md
@@ -1,0 +1,87 @@
+# Write your first ritual in 5 minutes
+
+A ritual is a recurring task you've turned into a slash command — a short markdown prompt you run by name. This kit ships a few (`/morning-briefing`, `/midday-checkin`, `/end-of-day`, `/weekly-review`). The fastest way to get your own is to copy one and tweak it. Here's the whole thing, start to finish.
+
+We'll turn the built-in `/midday-checkin` into a new `/inbox-sweep` — "what came in, what needs a reply, what can wait." Same shape, different job. Swap in whatever recurring task you dread; the steps are identical.
+
+## 1. Look at the one you're copying — 30 sec
+
+Open `.claude/commands/midday-checkin.md`. Every ritual has the same two parts:
+
+```markdown
+---
+description: Mid-day reset — what's done, what's slipping, what to protect this afternoon.
+---
+
+# Midday Check-in
+
+A quick reset. In order:
+
+1. Read `ops/priorities.md` ...
+2. Mark what's done ...
+3. Name the one thing that must happen this afternoon ...
+```
+
+- The bit between the `---` lines is the **frontmatter**. Its `description` is what shows up when you type `/` in Claude Code.
+- Everything below is the **prompt** — plain instructions, usually a short numbered list. That's the whole ritual.
+
+## 2. Copy it to a new name — 30 sec
+
+The file name *is* the command name. Copy it:
+
+```bash
+cp .claude/commands/midday-checkin.md .claude/commands/inbox-sweep.md
+```
+
+(No terminal handy? Duplicate the file in your editor and rename it — same thing.) `inbox-sweep.md` becomes `/inbox-sweep`. Lowercase, dashes for spaces.
+
+## 3. Rewrite the description — 1 min
+
+Open your new `inbox-sweep.md` and change the `description` to what this ritual actually does. This line is the trigger — it's what you see in the menu — so make it concrete:
+
+```markdown
+---
+description: Inbox sweep — what needs a reply now, what can wait, what to ignore.
+---
+```
+
+## 4. Rewrite the steps — 2 min
+
+Now the body. Keep the shape — a title and a short numbered list — and put your job in it. Tell it what to read, what to decide, and what to hand back:
+
+```markdown
+# Inbox Sweep
+
+Clear the noise. In order:
+
+1. List anything waiting on a reply from me — newest first.
+2. Sort into three: **reply now** (matters today), **can wait**, **ignore**.
+3. For each "reply now", draft a one-line response I can send or edit.
+
+Keep it short. Don't show me the "ignore" pile unless I ask.
+```
+
+Two things make a ritual work:
+
+- **Be specific about inputs and outputs.** "List what's waiting on a reply, newest first" beats "check my inbox." A clear, specific `description` matters for the same reason — it's the trigger.
+- **Say what *not* to do.** "Don't show me the ignore pile" keeps it from rambling.
+
+(`/midday-checkin` ends with a `## Depth` block — quick / standard / deep variants of the same ritual. Keep and adapt it if you like the option, or just delete it. It's optional.)
+
+## 5. Run it — 30 sec
+
+In Claude Code, type `/` and you'll see `inbox-sweep` in the list. Run it:
+
+```
+/inbox-sweep
+```
+
+That's a ritual. If it doesn't show up yet, start a fresh session so Claude Code picks up the new file.
+
+## 6. Make it a habit
+
+One ritual, run daily for a week, beats ten you set up once and forget. When `/inbox-sweep` feels automatic, copy it again for the next thing you dread. Commit it — `git add .claude/commands/inbox-sweep.md && git commit` — and your rituals get a history like everything else here.
+
+---
+
+Want it to reach your real inbox, calendar, or CRM? That's what MCP servers are for — see **Connect your tools** under [Make it yours](../README.md#make-it-yours) in the README.


### PR DESCRIPTION
## Summary

Implements the three open issues, one focused commit each, plus a changelog entry.

### #8 — Expand secret patterns in `pre-commit-guard.sh`
Broadened the commit guard to cover the common credential formats and documented the covered set inline so it's easy to extend:
- **GitHub** — all token prefixes (`ghp_`/`gho_`/`ghs_`/`ghr_`/`ghu_`) + fine-grained `github_pat_…`
- **Google API keys** — `AIza…` (39 chars)
- **Stripe** — `sk_live_…` / `rk_live_…`
- (kept) AWS `AKIA…`, Slack `xox[baprs]-…`, OpenAI `sk-…`, PEM private keys, generic `password/api_key/secret/token = …`

### #9 — Shellcheck CI for the hook scripts
New `.github/workflows/shellcheck.yml` lints `.claude/hooks/*.sh` on `push` and `pull_request`. Path-filtered to the hook scripts + the workflow file, so unrelated changes don't trigger it. Uses the shellcheck preinstalled on `ubuntu-latest` — no third-party action, nothing to pin.

### #10 — "Write your first ritual in 5 minutes" guide
New `docs/first-ritual.md`: a friendly walkthrough that copies the built-in `/midday-checkin` and adapts it into the reader's own `/inbox-sweep` ritual, end to end in ~5 minutes. Linked from the README "Make it yours" section.

## Test plan

- [x] **#8** All 11 credential samples (AWS, GitHub classic/oauth/fine-grained, Slack, Google, Stripe live/restricted, OpenAI, PEM, generic) are caught; benign lines (`const greeting = …`, `refreshToken()`, `task-list = []`) produce **no false positives**.
- [x] **#8** End-to-end: the actual hook **blocks** a staged fake AWS key and **passes** a benign staged change.
- [x] **#9** `shellcheck .claude/hooks/*.sh` is **green** against all current hooks (incl. the edited guard).
- [x] **#9** A deliberately broken script fails: both a syntax error and an info-level `SC2086` make shellcheck exit `1`, so CI catches real issues.
- [x] **#9** Workflow YAML parses; lint scoped to the hook scripts only.
- [x] **#10** Walkthrough is followable end to end in ~5 min, uses an existing command as the worked example, and is linked from the README (anchor verified).
- [x] **#9** Workflow run is **green** on this PR ([run](https://github.com/etrebels/claude-code-growth-os/actions/runs/26446156297)).

Closes #8
Closes #9
Closes #10

https://claude.ai/code/session_01BkrwXSzP1upKcnYabQeZEL