### PR TITLE
Add optional "Connecting a CRM" pattern doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Nothing there is real — delete `demo/` whenever you like.
 | `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (net revenue retention), and the three shared definitions |
 | `docs/methodology.md` | The idea in full: Claude Code as an operating environment |
 | `docs/why-align.md` | The one-page argument: why your whole go-to-market (marketing, sales, product, retention) runs as one system (with sources) |
+| `docs/connecting-a-crm.md` | Optional: make an existing CRM the source of truth and project it into `ops/pipeline.md` — don't run two pipelines |
 
 **Skills by function** — the motion is balanced across the bowtie, not just acquisition:
 
@@ -104,7 +105,7 @@ All pure bash (one uses `python3` to read a payload). No API keys, no MCP — it
 - **`ops/`** — one file per area. Don't port your whole life on day one; pick the ritual you dread most and make it real.
 - **`.claude/commands/`** — a ritual is just a markdown prompt. Copy one and tweak it — [write your first in 5 minutes](docs/first-ritual.md).
 - **`.claude/skills/`** — a repeatable job, triggered by its `description`. Copy one of the included skills as a pattern.
-- **Connect your tools** — copy `.mcp.json.example` → `.mcp.json` (gitignored) to add MCP servers (calendar, notes, issue tracker, CRM), and put any keys in `.claude/settings.local.json` (copy `.claude/settings.local.example.json`). Your commands and skills can then reach them.
+- **Connect your tools** — copy `.mcp.json.example` → `.mcp.json` (gitignored) to add MCP servers (calendar, notes, issue tracker, CRM), and put any keys in `.claude/settings.local.json` (copy `.claude/settings.local.example.json`). Your commands and skills can then reach them. If a CRM is your system of record, [`docs/connecting-a-crm.md`](docs/connecting-a-crm.md) shows how to project it into `ops/pipeline.md` instead of running two pipelines.
 
 ## Portability
 

--- a/docs/connecting-a-crm.md
+++ b/docs/connecting-a-crm.md
@@ -1,0 +1,41 @@
+# Connecting a CRM (optional)
+
+This kit works fine with [`ops/pipeline.md`](../ops/pipeline.md) as your hand-maintained board. But if you already have a CRM (HubSpot, Salesforce, Attio, …), **don't run two pipelines.** Make your CRM the source of truth and treat `ops/pipeline.md` as a *projection* of it. A hand-typed board that drifts from the CRM is worse than no board.
+
+## The pattern: project, don't duplicate
+
+```
+CRM (system of record)  ──hydrate──▶  ops/pipeline.md (snapshot)  ──you work──▶  CRM (write back)
+```
+
+- **Morning:** the briefing reads the CRM's open opportunities and rewrites the `ops/pipeline.md` table.
+- **During the day:** you glance at `ops/pipeline.md` (fast, no API call per look).
+- **End of day:** stage moves get written *back* to the CRM; the board re-projects.
+
+If the CRM is unreachable, fall back to the last projection and flag it stale — never block the routine.
+
+## Hard-won rules (these will bite you otherwise)
+
+1. **Never hardcode the API surface.** Discover endpoints, fields, and especially **select-option IDs** (pipeline stages) from the CRM's own schema endpoint each session — they're org-specific and change. Writing a stage *label* where the API wants an option *ID* silently fails.
+2. **Your stages won't match the CRM's.** The stage model you keep in [`ops/pipeline.md`](../ops/pipeline.md) — and the motion in [`operating-model.md`](operating-model.md) — rarely maps 1:1 to a CRM's stage list. Keep the conceptual model for coaching; report deals in the CRM's actual stages; document the mapping once.
+3. **Check relationship cardinality before writing.** Linking people to a deal (champion, economic buyer) is usually a *many* relationship — append (`add`), don't `replace`.
+4. **Find-or-create, always.** Search by name before creating an account, contact, or opportunity. Bulk imports without a dedup check are how CRMs rot.
+5. **Filter the exhaust.** Most CRMs are mostly closed/disqualified records. Project only the *open* set; compute the forecast only from real, weighted stages.
+6. **Render live; don't commit a giant snapshot.** Don't paste 200 deals into a committed file — it's stale the next day. Commit a thin "last hydrated" sample + the hydration spec; let the routine render the full set on demand.
+
+## Reconciling notes ↔ CRM
+
+If you keep per-deal working files, they drift from the CRM. A deal with a rich dossier but no CRM record is research that never became a tracked deal. Periodically reconcile: find-or-create the account + one opportunity, link the **named** committee (skip unnamed hypotheses), set a conservative stage. Keep the narrative in the working file; keep structured fields in the CRM. Don't duplicate.
+
+## Working with large CRM responses
+
+A full-pipeline list call can be large. Page deliberately (most list APIs cap page size and serve a search index that lags — use a single-record fetch when you need freshness). For analysis, stream the response through a query tool (`jq`) or a sub-agent rather than loading the whole dump into context.
+
+---
+
+*Vendor-neutral by design. Wire it to your CRM's specific API in a private rule/skill — keep credentials and internal IDs out of this repo.*
+
+## See also
+
+- [`operating-model.md`](operating-model.md) — the spine: where `ops/pipeline.md` sits in the four-function motion (handoff H1).
+- [`../ops/pipeline.md`](../ops/pipeline.md) — the board this projects into.

--- a/ops/pipeline.md
+++ b/ops/pipeline.md
@@ -1,7 +1,9 @@
 # Pipeline
 
 <!-- Your real pipeline — one row per active deal. The rituals and skills read this.
-     A fictional example lives in demo/pipeline.md. -->
+     A fictional example lives in demo/pipeline.md.
+     If a CRM is your system of record, this board is a projection of it —
+     see docs/connecting-a-crm.md (don't run two pipelines). -->
 
 | Account | Stage | Last activity | Next step | Health |
 |---|---|---|---|---|


### PR DESCRIPTION
## Summary
- Adds `docs/connecting-a-crm.md` — a vendor-neutral guide for the "project, don't duplicate" pattern: make an existing CRM (HubSpot, Salesforce, Attio, …) the system of record while keeping `ops/pipeline.md` as a projection of it.
- Links it from the README (the `docs/` table in "What's inside" and the "Connect your tools" bullet under "Make it yours").
- Adds a one-line pointer in `ops/pipeline.md` itself, so a CRM user discovers the pattern right where the projection lands.

## Why
The kit ships with a hand-maintained `ops/pipeline.md`. Anyone who already runs a CRM needs guidance to avoid two drifting pipelines. The doc captures the hydrate → work → write-back loop plus the hard-won rules (discover stage option-IDs at runtime, find-or-create, append many-relationships, project only the open set, render live instead of committing a giant snapshot).

## Fit with this repo
- Adapted to the public repo's structure — no `growth-os/` folder here, so the stage-model reference points to `docs/operating-model.md` and `ops/pipeline.md` instead.
- Matches the `docs/` house style (lead paragraph, sections, a "See also" footer).
- Vendor-neutral by design — CRM-specific API surface and any credentials/IDs stay in a private rule/skill, out of the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_011CG1g8CBxP7Z21SYHbaMEg)_