### PR TITLE
Sync docs with the CRM integration; link the scrub checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Connecting-a-CRM guide** (`docs/connecting-a-crm.md`) — an optional pattern
+  for making an existing CRM the system of record and projecting it into
+  `ops/pipeline.md`, so you never run two pipelines. (#12)
 - **First-ritual guide** (`docs/first-ritual.md`) — a 5-minute walkthrough that
   copies `/midday-checkin` into your own ritual, linked from the README. (#10)
 - **Shellcheck CI** (`.github/workflows/shellcheck.yml`) — lints the bash hooks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,7 @@ This is a plain-text starter — no server, no database, no build step, no telem
 
 - The `demo/` data is fictional by design. The safe way to present or share is to run from `demo/`.
 - Don't commit real prospect names, deals, or meeting notes to a repo you intend to publish — that is third-party personal data.
+- **Before you flip a fork to public, run the [pre-launch scrub checklist](docs/launch-scrub-checklist.md)** — copy-paste commands that scan the working tree *and* full git history for secrets and other people's data.
 
 ## Reporting
 

--- a/docs/connecting-a-crm.md
+++ b/docs/connecting-a-crm.md
@@ -14,6 +14,45 @@ CRM (system of record)  ──hydrate──▶  ops/pipeline.md (snapshot)  ─�
 
 If the CRM is unreachable, fall back to the last projection and flag it stale — never block the routine.
 
+## Wiring it up
+
+Give Claude Code reach into the CRM without putting a secret in git. Copy `.mcp.json.example` → `.mcp.json` (gitignored) and register the server alongside `filesystem`.
+
+**If your CRM has an MCP server** (hosted, or a thin local wrapper) — a local/stdio one:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "."] },
+    "crm": {
+      "command": "npx",
+      "args": ["-y", "your-crm-mcp-server"],
+      "env": { "CRM_API_KEY": "${CRM_API_KEY}" }
+    }
+  }
+}
+```
+
+A hosted/remote one instead, with the token on the `Authorization` header:
+
+```json
+"crm": {
+  "type": "http",
+  "url": "https://mcp.your-crm.example/v1",
+  "headers": { "Authorization": "Bearer ${CRM_API_KEY}" }
+}
+```
+
+Keep the real key out of `.mcp.json`. Put it in `.claude/settings.local.json` (also gitignored) and let `${CRM_API_KEY}` expand from there:
+
+```json
+{ "env": { "CRM_API_KEY": "your-key-here" } }
+```
+
+**If it only has a REST API**, the projection logic — find-or-create, paging, the stage-ID mapping below — lives in a **private skill** that calls the API, not in this repo. Keep org-specific endpoints and IDs there.
+
+Either way, a rule or skill then reads the CRM and rewrites `ops/pipeline.md` in the morning, and writes stage moves back at end of day — the loop at the top of this doc.
+
 ## Hard-won rules (these will bite you otherwise)
 
 1. **Never hardcode the API surface.** Discover endpoints, fields, and especially **select-option IDs** (pipeline stages) from the CRM's own schema endpoint each session — they're org-specific and change. Writing a stage *label* where the API wants an option *ID* silently fails.

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -67,3 +67,4 @@ The mature version of this is RevOps — one operating model and one data spine 
 
 - [`why-align.md`](why-align.md) — the one-page argument, with sources, for why the four belong in one system.
 - [`methodology.md`](methodology.md) — Claude Code as the operating environment the model runs in.
+- [`connecting-a-crm.md`](connecting-a-crm.md) — optional: make an existing CRM the system of record and project it into `ops/pipeline.md` (the H1 surface), instead of running two pipelines.


### PR DESCRIPTION
## Summary

The `connecting-a-crm` guide (#12) landed without being threaded through the rest of the docs. This closes those gaps and fixes one unrelated orphaned doc found while sweeping for consistency.

**CRM integration sync**
- **`CHANGELOG.md`** — record the connecting-a-crm guide under `[Unreleased] → Added`. PR #11 logged #8–#10, then the CRM doc (#12) landed and the changelog was never updated.
- **`docs/connecting-a-crm.md`** — add a **"Wiring it up"** section. The doc told you to connect a CRM via `.mcp.json` but never showed how. Now it gives concrete snippets for both a stdio and a remote MCP server, with the API key kept in the gitignored `settings.local.json` (referenced via `${CRM_API_KEY}`) rather than the committed config.
- **`docs/operating-model.md`** — add the missing back-link to `connecting-a-crm.md` in "See also". The CRM doc linked *to* the operating model but not vice-versa; the link is now bidirectional.

**Consistency fix (found while sweeping)**
- **`SECURITY.md`** — link the previously-orphaned `docs/launch-scrub-checklist.md` from the "Keep real client data out of a public fork" section. Nothing in the repo linked to it; that section is exactly its purpose.

The rest of the consistency sweep came back clean: all internal links + anchors resolve, hook/command/skill counts match the prose, and terminology (NRR, CS, MQL→SQL) is consistent. The `ops/icp.md` references are intentionally hedged ("if you keep one") and consistent with the bring-your-own-playbooks design, so they were left as-is.

## Test plan

- [ ] `CHANGELOG.md` renders; the new entry sits at the top of `[Unreleased] → Added`.
- [ ] `docs/connecting-a-crm.md` renders; the three JSON blocks are readable and the section reads in order (pattern → wiring → hard-won rules).
- [ ] The new links resolve: `operating-model.md` → `connecting-a-crm.md`, and `SECURITY.md` → `docs/launch-scrub-checklist.md`.
- [ ] No real secrets/data introduced (docs only; placeholders use `your-key-here` / `your-crm.example`).

https://claude.ai/code/session_01SQwS64LFiv4JejHf6iPdHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQwS64LFiv4JejHf6iPdHq)_