### PR TITLE
Seed ops/priorities.md with starter day-one priorities

### DIFF
--- a/ops/priorities.md
+++ b/ops/priorities.md
@@ -1,8 +1,9 @@
 # Priorities
 
 <!-- The SessionStart hook surfaces this file every time you open a session.
-     Keep it to 3-5 lines. Edit it whenever your focus changes. -->
+     Keep it to 3-5 lines. Edit it whenever your focus changes.
+     These three are starter priorities — replace them with your own. -->
 
-1. (your top priority)
-2. (your second)
-3. (your third)
+1. Build the daily habit — run `/morning-briefing` every working day this week, and `/end-of-day` to log it. The loop only works if it runs daily.
+2. Fill `ops/pipeline.md` with my real active deals (one row each) so the briefing has something real to read.
+3. Start one new conversation this week — pick one target account and send a single note.


### PR DESCRIPTION
## Summary
- Replace the empty `(your top priority)` placeholders in `ops/priorities.md` with three actionable day-one priorities, so a brand-new user's first session opens with real focus instead of a blank template.
- The three lines embody the kit's own onboarding guidance — build the daily ritual habit, populate the pipeline, start one new conversation — and a comment flags them as starters to replace.

## Test plan
- [ ] Open a session in the repo and confirm the SessionStart hook surfaces the three seeded priorities.
- [ ] Confirm the lines read as replaceable starters (the comment notes "replace them with your own").

https://claude.ai/code/session_019Z7CXYNtCiABftEUAVzm9h

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z7CXYNtCiABftEUAVzm9h)_