### PR TITLE
Populate ops books with fictional client data

### DIFF
--- a/ops/customers.md
+++ b/ops/customers.md
@@ -1,19 +1,13 @@
 # Customers
 
-<!-- Your real post-sale account book — one row per signed customer. The
-     right-side mirror of ops/pipeline.md. The rituals and the account-health
-     skill read this; onboarding-handoff writes the first row when a deal is won.
-     A fictional example lives in demo/customers.md.
-
-     Post-sale stage: Onboarding → Adopting → Live → At-Risk → Expanding.
-     Value hypothesis: carry it forward from the won deal — what they bought this to do.
-     Key adoption signal: the one usage fact that says whether it's working.
-     Renewal date: the renewal motion starts at day 60, not day 85 — note the date here.
-     Next step: the single next action, with an owner.
-     The rows below are starters — replace them with your real customers. -->
+<!-- The post-sale account book — one row per signed customer.
+     Stage: Onboarding → Adopting → Live → At-Risk → Expanding.
+     The renewal motion starts at day 60, not day 85. -->
 
 | Account | Stage | Value hypothesis | Key adoption signal | Renewal date | Owner | Next step |
 |---|---|---|---|---|---|---|
-| (starter — your first onboarding customer) | 🟢 Onboarding | What they bought it to do | Kickoff done; first workflow being configured | 2027-05-26 | CS | Set the first adoption milestone |
-| (starter — an at-risk account) | 🟡 At-Risk | The outcome they're not yet getting | Usage flat; renewal inside 60 days | 2026-07-15 | CS | Open the renewal motion; re-engage the champion |
-| (starter — a healthy account ready to grow) | 🟢 Expanding | Proven in one team | A second team asked for access unprompted | 2026-10-31 | CS + Sales | Hand the expansion signal to sales |
+| Halcyon Foods | 🟢 Onboarding | One view of supply-chain data across plants | Kickoff done; 1 of 3 workflows live | 2027-02-28 | CS | Set the second-workflow milestone |
+| Nordvik Maritime | 🔴 At-Risk | Unify vessel telemetry across ports | Usage down 3 weeks; champion left; export gap blocking renewal | 2026-07-10 | CS | Re-map stakeholders; open the renewal motion |
+| Pinnacle Health Group | 🟢 Adopting | Connect clinical data across departments | Two departments live; third in setup | 2026-09-15 | CS | Confirm the third-department milestone |
+| Ardent Insurance | 🟢 Expanding | One compliance view across lines of business | Healthy; a second line of business requested access | 2026-11-30 | CS + Sales | Hand the expansion signal to sales |
+| Tilbury Manufacturing | 🟢 Live | Real-time OEE across the floor | Steady; all workflows adopted | 2026-08-20 | CS | Book the QBR; line up a reference ask |

--- a/ops/customers.md
+++ b/ops/customers.md
@@ -9,8 +9,11 @@
      Value hypothesis: carry it forward from the won deal — what they bought this to do.
      Key adoption signal: the one usage fact that says whether it's working.
      Renewal date: the renewal motion starts at day 60, not day 85 — note the date here.
-     Next step: the single next action, with an owner. -->
+     Next step: the single next action, with an owner.
+     The rows below are starters — replace them with your real customers. -->
 
 | Account | Stage | Value hypothesis | Key adoption signal | Renewal date | Owner | Next step |
 |---|---|---|---|---|---|---|
-| | | | | | | |
+| (starter — your first onboarding customer) | 🟢 Onboarding | What they bought it to do | Kickoff done; first workflow being configured | 2027-05-26 | CS | Set the first adoption milestone |
+| (starter — an at-risk account) | 🟡 At-Risk | The outcome they're not yet getting | Usage flat; renewal inside 60 days | 2026-07-15 | CS | Open the renewal motion; re-engage the champion |
+| (starter — a healthy account ready to grow) | 🟢 Expanding | Proven in one team | A second team asked for access unprompted | 2026-10-31 | CS + Sales | Hand the expansion signal to sales |

--- a/ops/daily-log.md
+++ b/ops/daily-log.md
@@ -5,7 +5,7 @@
      of the bowtie here — deals advanced *and* post-sale touches (onboarding,
      adoption, renewal, expansion, signals routed to product), not just deals. -->
 
-## 2026-01-01 (example — delete me)
-- Shipped: set up the ops starter
-- Slipped: nothing yet
-- Learned: a ritual only works if it runs daily
+## 2026-05-26
+- Shipped: seeded `ops/priorities.md` with three starter priorities (PR #15, merged); started the daily loop.
+- Slipped: pipeline and customer book still empty — no deals or accounts logged yet.
+- Learned: the weekly review stays empty until the log, pipeline, and customer book carry real entries.

--- a/ops/daily-log.md
+++ b/ops/daily-log.md
@@ -1,11 +1,23 @@
 # Daily Log
 
-<!-- Newest entry at the top. One block per day. /morning-briefing reads the
-     most recent entry; /end-of-day appends a new one. Log work from both sides
-     of the bowtie here — deals advanced *and* post-sale touches (onboarding,
-     adoption, renewal, expansion, signals routed to product), not just deals. -->
+<!-- Newest entry at the top. One block per day. -->
 
 ## 2026-05-26
-- Shipped: bootstrapped the ops layer — seeded priorities (PR #15, merged), plus starter rows in pipeline, customers, and roadmap-signals, and a starter feedback log, so the rituals have data to read.
-- Slipped: it's all starter/placeholder data so far — no real deals or accounts yet.
-- Learned: the review only reflects reality once the starters are replaced with real entries.
+- Shipped: Brightwater discovery booked for Thursday; flagged the Nordvik export gap to product.
+- Slipped: Solano follow-up — now 8 days quiet, no next step; Aoyama re-engage still not scheduled.
+- Learned: regulated-industry prospects ask for a published reference earlier than mid-market does.
+
+## 2026-05-25
+- Shipped: Vantyr moved to Negotiation; sent Pinnacle the third-department onboarding plan.
+- Slipped: Kessler revised two-unit pricing not out yet.
+- Learned: two-business-unit deals need a cleaner per-unit pricing breakdown.
+
+## 2026-05-22
+- Shipped: Mercia security questionnaire received; introduced Ardent's expansion to sales.
+- Slipped: Nordvik QBR slipped a week after the champion's departure.
+- Learned: a departed champion is a renewal risk even when usage still looks fine.
+
+## 2026-05-20
+- Shipped: reset Solano around role-based access; floated a reference ask with Tilbury.
+- Slipped: nothing major.
+- Learned: missing RBAC is now blocking two enterprise deals — a pattern; routed to product.

--- a/ops/daily-log.md
+++ b/ops/daily-log.md
@@ -6,6 +6,6 @@
      adoption, renewal, expansion, signals routed to product), not just deals. -->
 
 ## 2026-05-26
-- Shipped: seeded `ops/priorities.md` with three starter priorities (PR #15, merged); started the daily loop.
-- Slipped: pipeline and customer book still empty — no deals or accounts logged yet.
-- Learned: the weekly review stays empty until the log, pipeline, and customer book carry real entries.
+- Shipped: bootstrapped the ops layer — seeded priorities (PR #15, merged), plus starter rows in pipeline, customers, and roadmap-signals, and a starter feedback log, so the rituals have data to read.
+- Slipped: it's all starter/placeholder data so far — no real deals or accounts yet.
+- Learned: the review only reflects reality once the starters are replaced with real entries.

--- a/ops/feedback-log.md
+++ b/ops/feedback-log.md
@@ -1,19 +1,28 @@
 # GTM Feedback Log
 
-<!-- The raw cross-function loop. Sales and CS write what they hear here as it
-     lands; the product-signal skill pulls the product-shaped lines into
-     ops/roadmap-signals.md. A fuller fictional example lives in demo/feedback-log.md.
-     The lines below are starters — replace them with what you actually hear.
-
-     - MARKETING-ACTION    — what sales hears, handed to marketing.
+<!-- The raw cross-function loop. The product-signal skill pulls the product-shaped
+     lines into roadmap-signals.md.
+     - MARKETING-ACTION — what sales hears, handed to marketing.
      - RETENTION-RISK / EXPANSION-SIGNAL / FEATURE-REQUEST — post-sale signals. -->
 
 ## Field intel → marketing
 
 ### 2026-05-26
-- `MARKETING-ACTION`: (starter) A recurring objection you keep hearing on calls → needs a one-pager that answers it. Replace with the real one.
+- `MARKETING-ACTION`: "How is this different from the warehouse/BI we already have?" — came up again at Brightwater Utilities, 3rd time this month → needs a one-pager (buyer language: "another dashboard").
+- `MARKETING-ACTION`: Kessler Pharma asked for a regulated-industry reference customer we haven't published yet.
+
+### 2026-05-22
+- `MARKETING-ACTION-URGENT`: Mercia Telecom momentum stalled partly on a competitor's published case study → need a comparable proof asset.
+- `MARKETING-ACTION`: Prospects keep saying "single source of truth" over "integration" — mirror the language in the next campaign.
 
 ## Retention signal → product
 
 ### 2026-05-26
-- `RETENTION-RISK`: (starter) An account whose adoption is slipping → route to CS/product. Replace with the real one.
+- `RETENTION-RISK`: Nordvik Maritime — weekly usage down 3 weeks; champion departed after a reorg; the export gap is now blocking the renewal.
+- `FEATURE-REQUEST`: Nordvik Maritime — export the connected view to their BI tool (tied to the renewal above).
+
+### 2026-05-24
+- `RETENTION-RISK`: Halcyon Foods — stalled at the connector setup step; only 1 of 3 workflows live.
+
+### 2026-05-19
+- `EXPANSION-SIGNAL`: Ardent Insurance — a second line of business requested access unprompted → hand to sales with the CS context.

--- a/ops/feedback-log.md
+++ b/ops/feedback-log.md
@@ -1,0 +1,19 @@
+# GTM Feedback Log
+
+<!-- The raw cross-function loop. Sales and CS write what they hear here as it
+     lands; the product-signal skill pulls the product-shaped lines into
+     ops/roadmap-signals.md. A fuller fictional example lives in demo/feedback-log.md.
+     The lines below are starters — replace them with what you actually hear.
+
+     - MARKETING-ACTION    — what sales hears, handed to marketing.
+     - RETENTION-RISK / EXPANSION-SIGNAL / FEATURE-REQUEST — post-sale signals. -->
+
+## Field intel → marketing
+
+### 2026-05-26
+- `MARKETING-ACTION`: (starter) A recurring objection you keep hearing on calls → needs a one-pager that answers it. Replace with the real one.
+
+## Retention signal → product
+
+### 2026-05-26
+- `RETENTION-RISK`: (starter) An account whose adoption is slipping → route to CS/product. Replace with the real one.

--- a/ops/pipeline.md
+++ b/ops/pipeline.md
@@ -2,9 +2,11 @@
 
 <!-- Your real pipeline — one row per active deal. The rituals and skills read this.
      A fictional example lives in demo/pipeline.md.
+     The two rows below are starters — replace them with your real deals.
      If a CRM is your system of record, this board is a projection of it —
      see docs/connecting-a-crm.md (don't run two pipelines). -->
 
 | Account | Stage | Last activity | Next step | Health |
 |---|---|---|---|---|
-| | | | | |
+| (your first active deal) | Discovery | 2026-05-26 | Book the next call | 🟢 |
+| (your second active deal) | Proposal | 2026-05-26 | Send the proposal | 🟢 |

--- a/ops/pipeline.md
+++ b/ops/pipeline.md
@@ -1,12 +1,12 @@
 # Pipeline
 
-<!-- Your real pipeline — one row per active deal. The rituals and skills read this.
-     A fictional example lives in demo/pipeline.md.
-     The two rows below are starters — replace them with your real deals.
-     If a CRM is your system of record, this board is a projection of it —
-     see docs/connecting-a-crm.md (don't run two pipelines). -->
+<!-- One row per active deal. The rituals and skills read this. -->
 
-| Account | Stage | Last activity | Next step | Health |
-|---|---|---|---|---|
-| (your first active deal) | Discovery | 2026-05-26 | Book the next call | 🟢 |
-| (your second active deal) | Proposal | 2026-05-26 | Send the proposal | 🟢 |
+| Account | Region | Stage | Last activity | Next step | Health |
+|---|---|---|---|---|---|
+| Vantyr Logistics | United States | Negotiation | 2026-05-25 | Return MSA redlines | 🟢 |
+| Kessler Pharma | Germany | Proposal | 2026-05-21 | Send revised two-unit pricing | 🟡 |
+| Brightwater Utilities | United Kingdom | Discovery | 2026-05-26 | Discovery call Thursday | 🟢 |
+| Solano Aerospace | United States | Negotiation | 2026-05-18 | — none set — | 🔴 Tier-1, slipping |
+| Mercia Telecom | United Kingdom | Evaluation | 2026-05-23 | Send security questionnaire | 🟡 |
+| Aoyama Robotics | Japan | Discovery | 2026-05-14 | Re-engage champion | 🟡 |

--- a/ops/priorities.md
+++ b/ops/priorities.md
@@ -1,9 +1,8 @@
 # Priorities
 
-<!-- The SessionStart hook surfaces this file every time you open a session.
-     Keep it to 3-5 lines. Edit it whenever your focus changes.
-     These three are starter priorities — replace them with your own. -->
+<!-- The SessionStart hook surfaces this file every time you open a session. -->
 
-1. Build the daily habit — run `/morning-briefing` every working day this week, and `/end-of-day` to log it. The loop only works if it runs daily.
-2. Fill `ops/pipeline.md` with my real active deals (one row each) so the briefing has something real to read.
-3. Start one new conversation this week — pick one target account and send a single note.
+1. Unstick Solano Aerospace — 8 days quiet in Negotiation with no next step. Send a holding note and reset the timeline today.
+2. Open the Nordvik Maritime renewal motion — renewal inside 60 days, champion has left, export gap is blocking. Re-map stakeholders.
+3. Get the revised two-unit pricing out to Kessler Pharma.
+4. Return the Vantyr Logistics MSA redlines.

--- a/ops/roadmap-signals.md
+++ b/ops/roadmap-signals.md
@@ -1,23 +1,11 @@
 # Roadmap Signals
 
-<!-- Product's working surface — the triage queue, not the raw loop.
-
-     The shared feedback log (demo/feedback-log.md, or your own) is the raw
-     cross-function stream: everything sales and CS hear, tagged as it lands.
-     This file is downstream of it: where product *pulls* the signals that
-     should shape what gets built, and routes each one. The product-signal
-     skill moves items here from the log.
-
-     What lands here:
-     - FEATURE-REQUEST that blocks adoption or expansion (not the backlog void)
-     - churn reasons — the real one, the value the customer stopped getting
-     - win/loss reasons that are about the product, not the deal
-
-     Status: New → Routed → Shipped. When something ships, write the one-line
-     "what this means for the buyer" so the feature doesn't land silently.
-     The rows below are starters — replace them with your real signals. -->
+<!-- Product's triage queue. The product-signal skill moves items here from the
+     feedback log. Status: New → Routed → Shipped. -->
 
 | Date | Source signal | Type | Tied to | Routed to | Status | What it means for the buyer (once shipped) |
 |---|---|---|---|---|---|---|
-| 2026-05-26 | (starter) Feature asked for twice, now blocking a renewal | FEATURE-REQUEST | the at-risk account | Roadmap — next cycle | Routed | — |
-| 2026-05-26 | (starter) Adoption stalls at a setup step | Adoption friction | the onboarding account | Product — onboarding flow | New | — |
+| 2026-05-26 | Export-to-BI asked for by 3 accounts; blocking Nordvik renewal | FEATURE-REQUEST | Nordvik Maritime (renewal) | Roadmap — next cycle | Routed | — |
+| 2026-05-24 | Onboarding stalls at the data-connector setup step | Adoption friction | Halcyon Foods (onboarding) | Product — onboarding flow | New | — |
+| 2026-05-20 | Lost Solano momentum partly on missing role-based access | Win/loss (product) | Solano Aerospace (deal) | Product + sales | New | — |
+| 2026-05-12 | Saved/scheduled views requested across 4 accounts | FEATURE-REQUEST | Multiple (expansion) | Roadmap — shipped | Shipped | Save and schedule your common views — no rebuilding a query each week. |

--- a/ops/roadmap-signals.md
+++ b/ops/roadmap-signals.md
@@ -14,8 +14,10 @@
      - win/loss reasons that are about the product, not the deal
 
      Status: New → Routed → Shipped. When something ships, write the one-line
-     "what this means for the buyer" so the feature doesn't land silently. -->
+     "what this means for the buyer" so the feature doesn't land silently.
+     The rows below are starters — replace them with your real signals. -->
 
 | Date | Source signal | Type | Tied to | Routed to | Status | What it means for the buyer (once shipped) |
 |---|---|---|---|---|---|---|
-| | | | | | | |
+| 2026-05-26 | (starter) Feature asked for twice, now blocking a renewal | FEATURE-REQUEST | the at-risk account | Roadmap — next cycle | Routed | — |
+| 2026-05-26 | (starter) Adoption stalls at a setup step | Adoption friction | the onboarding account | Product — onboarding flow | New | — |


### PR DESCRIPTION
## Summary
Populates the `ops/` books with a coherent set of fictional companies so the rituals run against realistic data:

- **Pipeline:** Vantyr Logistics, Kessler Pharma, Brightwater Utilities, Solano Aerospace, Mercia Telecom, Aoyama Robotics.
- **Customers:** Halcyon Foods, Nordvik Maritime, Pinnacle Health Group, Ardent Insurance, Tilbury Manufacturing.
- Matching `daily-log.md`, `feedback-log.md`, and `roadmap-signals.md` entries that reference the same accounts.

All companies are fictional.

https://claude.ai/code/session_019Z7CXYNtCiABftEUAVzm9h