### PR TITLE
Correct sales statistics to verified primary sources

### DIFF
--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -35,7 +35,7 @@ A motion is only as strong as its handoffs. Each one has a **trigger**, an **own
 | **H6** | CS → Marketing | A customer reaches a clear outcome | CS | A reference / proof point — the customer's own words for the value they got |
 | **L** | Loop close | Weekly review | All four | `MARKETING-ACTION` cleared, `RETENTION-RISK` routed, references captured — read in `/weekly-review` |
 
-H1 and H2 are the loop most teams can see. H3–H6 are the right side of the bowtie — the half usually left with no owner. **H3 is the seam most teams never define**: a signed deal that drops into a CS void with no shared definition of *ready*. **H5 is the antidote to "build it and they will come"** — an often-cited rule of thumb is that ~80% of shipped features go rarely or never used, largely because they ship with no enablement and no buyer-facing reason to adopt them.
+H1 and H2 are the loop most teams can see. H3–H6 are the right side of the bowtie — the half usually left with no owner. **H3 is the seam most teams never define**: a signed deal that drops into a CS void with no shared definition of *ready*. **H5 is the antidote to "build it and they will come"** — Pendo (2019) found ~80% of features rarely or never used across its own accounts (vendor data), often because they ship with no enablement and no buyer-facing reason to adopt them.
 
 ## The one number, and a North Star
 
@@ -49,7 +49,7 @@ One shared number beats four local metrics — lead volume, bookings, ship count
 Written once, owned jointly, living as one file each — not four arguments in four tools.
 
 1. **One ICP.** Who you're for, agreed by sales and marketing in the same room. (`ops/icp.md` if you keep one — `lead-qualify` reads it.)
-2. **One MQL→SQL bar.** The single definition of a qualified lead both sides own — the H1 trigger. (Only ~8% of B2B firms even share this definition; documented SLAs correlate with ~34% higher odds of higher YoY ROI.)
+2. **One MQL→SQL bar.** The single definition of a qualified lead both sides own — the H1 trigger. (Documented SLAs correlate with ~34% higher odds of higher YoY ROI — HubSpot *State of Inbound* 2015, self-reported.)
 3. **One Won→onboarding definition.** What "ready to hand off" means — the H3 trigger and checklist, so a closed deal doesn't drop silently. (`onboarding-handoff` runs it.)
 
 ## How this kit maps to the model

--- a/docs/why-align.md
+++ b/docs/why-align.md
@@ -12,7 +12,7 @@ This kit keeps the whole motion in one repo on purpose. This page is the *why*: 
 
 The old model was a relay: marketing creates awareness and generates leads, sales takes over and sells, and what happens after the contract is signed is somebody else's problem. That assumed the buyer entered a conversation with a rep early, and that the sale was the finish line.
 
-Neither holds. The share of the B2B buying journey that happens **before any contact with sales** has climbed steadily — roughly 57% in 2015, ~70% by 2019, and ~80% by 2024. Gartner reports **67% of B2B buyers now prefer a rep-free buying experience**. So most persuasion happens on surfaces marketing owns, long before sales is in the room.
+Neither holds. A large and rising share of the B2B buying journey happens **before any contact with sales**. The citable anchor is CEB Marketing Leadership Council and Google (2012), which put it at **roughly 57%** — and Gartner reports **67% of B2B buyers now prefer a rep-free buying experience** (2026, up from 33% in 2019). So most persuasion happens on surfaces marketing owns, long before sales is in the room.
 
 And the finish line moved too. Draw the journey honestly and it isn't a funnel — it's a **bowtie**: demand and acquisition on the left, then the *wide* right half the funnel usually forgets — onboarding, adoption, renewal, expansion. Two of the three ways a company grows happen *after* the first sale. That's where **net revenue retention** lives — the number that now decides what a company is worth.
 
@@ -22,15 +22,15 @@ So the seams a buyer feels aren't only between marketing and sales. They're betw
 
 **Aligning sales and marketing already pays — that's the part most people have heard:**
 
-- SiriusDecisions (now Forrester) benchmarked roughly 400 B2B organizations: tightly aligned sales and marketing achieved **~24% faster three-year revenue growth and ~27% faster profit growth** — the most credible single figure in the literature.
-- IDC estimates the inability to align costs **10%+ of revenue per year**; broader estimates of revenue lost to siloed data and functions run **20–30%**. LinkedIn's "Art of Winning" puts the US aggregate near **$1 trillion a year**.
+- SiriusDecisions (now Forrester) benchmarked roughly 400 B2B organizations: tightly aligned sales and marketing achieved **~24% faster three-year revenue growth and ~27% faster profit growth** (vendor benchmark, self-reported) — the most credible single figure in the vendor literature.
+- IDC estimates the inability to align costs **10%+ of revenue per year**; broader estimates of revenue lost to siloed data and functions run **20–30%**. LinkedIn's "Art of Winning" puts the US aggregate near **$1 trillion a year** — an estimated figure, directional only.
 - A concrete waste line: **60–70% of the content marketing produces is never used by sales.**
 
 **The bigger, less-told leak is on the right side of the bowtie:**
 
-- **Net revenue retention is the valuation number.** Median NRR sits around **~106%** (higher for enterprise, lower for SMB). Below 100% means every dollar of acquisition spend is filling a leaking bucket — you grow by running faster, not by compounding.
-- **Premature scaling is the #1 startup killer.** Studies of high-growth startups attribute roughly **70%+ of failures** to scaling before the motion works — pouring acquisition into a product or post-sale experience that can't hold it.
-- **The feedback that would fix it gets lost.** Sales reps **misdiagnose why deals are won or lost 60–85% of the time**, so the real reason rarely reaches marketing or product. And an often-cited rule of thumb is that **~80% of shipped features go rarely or never used** — product building without the signal from the field and the customer base.
+- **Net revenue retention is the valuation number.** Median NRR sits around **~106%** (ChartMogul 2024 — higher for enterprise, lower for SMB). Below 100% means every dollar of acquisition spend is filling a leaking bucket — you grow by running faster, not by compounding.
+- **Premature scaling is the #1 startup killer.** The Startup Genome Report (2012) attributes **~74% of high-growth startup failures** to scaling before the motion works — pouring acquisition into a product or post-sale experience that can't hold it. (Self-reported; thresholds unpublished.)
+- **The feedback that would fix it gets lost.** Win/loss vendor Clozd reports that reps are **wrong about why deals are won or lost more than 60% of the time**, and that CRM win/loss data matched buyer interviews only **~15% of the time** across ~1,000 closed-lost deals — i.e., ~85% inaccurate. (Vendor data, method not fully published; the direction is what matters — run the loop on logged evidence, not memory.) So the real reason rarely reaches marketing or product. And feature usage skews low: Pendo (2019) found **~80% of features rarely or never used** across 615 of its own accounts — product building without the signal from the field and the customer base.
 
 Put together: the cost of misalignment isn't only the deals marketing and sales fumble between them. It's the renewals product never hears about and the expansions customer success never triggers.
 
@@ -38,7 +38,7 @@ Put together: the cost of misalignment isn't only the deals marketing and sales 
 
 If the case is this clear, why is it still rare? Two reasons.
 
-**The people who could fix the front half think it's already fixed.** Forrester's 2024 survey: **82% of C-level executives believed sales and marketing were in sync, while 65% of the practitioners reported the opposite.** Only about **8%** of companies are strongly aligned. The people on the ground see the seam daily; the people with authority to close it don't.
+**The people who could fix the front half think it's already fixed.** Forrester's 2024 work found a wide perception gap: a large majority of C-level executives believed sales and marketing were in sync, while most practitioners reported the opposite. (Two separate Forrester 2024 surveys, self-reported.) The people on the ground see the seam daily; the people with authority to close it don't.
 
 **And almost nobody instruments the back half.** Acquisition gets the dashboards; the post-sale motion gets wired last, if at all — so churn happens for reasons that never reach the roadmap, and expansion is left to chance. The most expensive gap is the one with no owner.
 
@@ -56,7 +56,7 @@ Goodwill can't out-run a broken incentive system. If you want different behavior
 
 Not constant meetings or a merged org chart — a small set of shared structures. The same handful that aligns sales and marketing extends to all four:
 
-1. **Shared definitions, written once.** One ICP. One MQL→SQL bar both sales and marketing own. One **Won→onboarding handoff** so a signed deal doesn't drop silently into a CS void. (Only ~8% of B2B firms even share an MQL/SQL definition; firms with documented SLAs are ~34% more likely to see higher YoY ROI.)
+1. **Shared definitions, written once.** One ICP. One MQL→SQL bar both sales and marketing own. One **Won→onboarding handoff** so a signed deal doesn't drop silently into a CS void. (Firms with documented SLAs are ~34% more likely to report higher YoY ROI — HubSpot *State of Inbound* 2015, self-reported.)
 2. **Two-way commitments (SLAs).** Marketing commits to lead volume *and quality*; sales commits to follow-up speed *and honest feedback*; sales commits to a complete handoff at won; CS commits to flag risk early (the renewal motion starts day 60, not day 85).
 3. **Shared goals — one revenue number.** A North Star that captures customer value, with **NRR** as the financial number the whole bowtie rolls up to. Not four separate local targets that pull apart.
 4. **One source of truth.** A shared system with closed-loop reporting, so all four reason from the same numbers.
@@ -89,7 +89,9 @@ You don't need everything on day one. A shared definition, a Won→onboarding ha
 
 ## 7. Honest caveats
 
-- **The exact percentages are soft.** Several of the most-quoted figures come from older or vendor-sponsored studies and vary between sources. Use them to make the case, not as guarantees. (One widely repeated "aligned orgs grow 36% faster" line is untraceable to a primary source — the 24% Forrester figure is the defensible one.)
+- **The exact percentages are soft.** Several of the most-quoted figures come from older or vendor-sponsored studies and vary between sources. Use them to make the case, not as guarantees. (A widely repeated "aligned orgs grow 36% faster" line is a garble of Forrester's actual "36% *more* revenue growth" — and the ~24% SiriusDecisions/Forrester figure is the cleaner one to lean on.)
+- **The "80% before sales" claim is a conflation — we don't make it.** The number you'll see everywhere fuses Gartner's "80% of B2B sales *interactions* will be in *digital channels* by 2025" (a different claim) with CEB/Google's real 2012 "57%." We anchor to the 57% and the rising trend, not to "80% before sales."
+- **The win/loss and feature-usage figures are vendor data.** The Clozd win/loss numbers and the Pendo feature-usage figure come from firms that sell into those problems, with methods not fully published. Treat them as directional support for running the loop on logged evidence, not as benchmark-grade magnitudes.
 - **Correlation isn't proof of causation.** Well-run companies tend to do both alignment *and* growth well, so some of the effect is selection. Treat alignment as necessary, not single-handedly sufficient.
 - **It matters most in considered B2B sales with real post-sale relationships** — long journeys, multiple stakeholders, renewals and expansion. For low-consideration or one-off purchases, the right-side payoff is smaller.
 
@@ -97,13 +99,46 @@ You don't need everything on day one. A shared definition, a Won→onboarding ha
 
 ## Sources
 
-- Gartner — 67% prefer a rep-free experience; ~80% of the journey before sales; RevOps guidance
-- Forrester / SiriusDecisions — the ~24% alignment economics; the 82%/65% perception gap; ~8% strongly aligned
-- IDC — cost of misalignment (10%+ of revenue/yr); revenue lost to silos (20–30%)
-- LinkedIn "Art of Winning" — the ~$1 trillion aggregate figure
-- Winning by Design — the bowtie model (retention and expansion as first-class growth engines)
-- ChartMogul / SaaS benchmarks — net revenue retention medians (~106%)
-- Startup Genome — premature scaling as the leading cause of high-growth startup failure
-- Clozd — reps misdiagnose win/loss reasons 60–85% of the time
-- Reforge — why funnels force siloed ownership and loops compound
-- HBR — "When Sales and Marketing Aren't Aligned, Both Suffer" (2018)
+The strongest evidence here is peer-reviewed. We lead with the academic work and keep the vendor benchmarks below it, labeled for what they are.
+
+### Peer-reviewed (lead with these)
+
+**Sales ↔ marketing alignment**
+
+- Kotler, Rackham & Krishnaswamy (2006), "Ending the War Between Sales and Marketing," *HBR* 84(7–8) — the canonical Undefined → Defined → Aligned → Integrated framework. https://hbr.org/2006/07/ending-the-war-between-sales-and-marketing
+- Homburg, Jensen & Krohmer (2008), "Configurations of Marketing and Sales: A Taxonomy," *Journal of Marketing* 72(2):133–154 — survey of 337 firms; best performers pair structural linkage with market knowledge. https://doi.org/10.1509/jmkg.72.2.133
+- Le Meunier-FitzHugh & Piercy (2007), "Does Collaboration Between Sales and Marketing Affect Business Performance?" *J. Personal Selling & Sales Management* 27(3):207–220 — direct collaboration → performance link. https://doi.org/10.2753/PSS0885-3134270301
+- Kirca, Jayachandran & Bearden (2005), "Market Orientation: A Meta-Analytic Review," *Journal of Marketing* 69(2):24–41 — market orientation → performance, mediated by innovativeness. https://people.duke.edu/~moorman/Marketing-Strategy-Seminar-2015/Session%202/Kirca,%20Jayachandran,%20and%20Bearden.pdf
+
+**Retention & loyalty economics**
+
+- Reichheld & Sasser (1990), "Zero Defections: Quality Comes to Services," *HBR* 68(5):105–111 — the origin of the retention-profit idea (firm-specific Bain cases). https://hbr.org/1990/09/zero-defections-quality-comes-to-services
+- Gupta, Lehmann & Stuart (2004), "Valuing Customers," *Journal of Marketing Research* 41(1):7–18 — a 1% improvement in retention ≈ 5% improvement in firm value; retention dominates acquisition. https://doi.org/10.1509/jmkr.41.1.7.25084
+- Reinartz & Kumar (2002), "The Mismanagement of Customer Loyalty," *HBR* 80(7):86–94 — the counter-weight: across ~16,000 customers, loyalty ≠ profitability. https://hbr.org/2002/07/the-mismanagement-of-customer-loyalty
+
+**Sales ↔ production / operations (S&OP)**
+
+- Oliva & Watson (2011), "Cross-functional alignment in supply chain planning," *Journal of Operations Management* 29(5):434–448 — the Leitax case: forecast accuracy 58%→88% after S&OP integration. https://doi.org/10.1016/j.jom.2010.11.012
+- Thomé et al. (2014), "The impact of sales and operations planning practices on manufacturing operational performance," *Int. J. Production Research* 52(7):2108–2121 — N=725 manufacturers, 34 countries; internal S&OP has a moderate-to-large effect on performance. https://doi.org/10.1080/00207543.2013.853889
+
+**Lead response, forecasting & the field→product feedback loop**
+
+- Oldroyd, McElheran & Elkington (2011), "The Short Life of Online Sales Leads," *HBR* — contacting a web lead within 1 hour was ~7× more likely to qualify it. https://hbr.org/2011/03/the-short-life-of-online-sales-leads
+- Gupta, Raj & Wilemon (1986), "A Model for Studying R&D–Marketing Interface in the Product Innovation Process," *Journal of Marketing* 50(2):7–17 — the integration gap drives innovation success. https://journals.sagepub.com/doi/abs/10.1177/002224298605000201
+- CSO Insights 2018–2019 Sales Performance Study (~900 leaders) — forecast win rate 47.3%; less than half of forecasted deals close. (CSO Insights is now defunct.)
+
+### Vendor benchmarks (directional, self-reported)
+
+- CEB Marketing Leadership Council + Google, *The Digital Evolution in B2B Marketing* (2012) — the citable origin of "~57% of the journey before sales." https://www.thinkwithgoogle.com/marketing-resources/b2b-digital-evolution/
+- Gartner — 67% of B2B buyers prefer a rep-free experience (2026, up from 33% in 2019); RevOps guidance. https://www.gartner.com/en/newsroom/press-releases/2026-03-09-gartner-sales-survey-finds-67-percent-of-b2b-buyers-prefer-a-rep-free-experience
+- Forrester / SiriusDecisions — the ~24%/27% alignment economics (vendor benchmark, self-reported); the 82% exec / practitioner perception gap (two separate 2024 surveys). https://www.forrester.com/blogs/the-truth-about-b2b-sales-and-marketing-alignment/
+- Forrester — "36% *more* revenue growth" for customer-obsessed firms. https://www.forrester.com/press-newsroom/customer-obsessed-growth-engine-alignment/
+- IDC — cost of misalignment (10%+ of revenue/yr); revenue lost to silos (20–30%). (Appears second-hand via *Aligned to Achieve*, Wiley 2016.)
+- LinkedIn "Art of Winning" — the ~$1 trillion aggregate (an estimated figure).
+- ChartMogul *SaaS Retention Report* (2024) — net revenue retention median ~106%. https://chartmogul.com/reports/saas-retention-report/
+- Startup Genome Report (2012) — ~74% of high-growth startups fail from premature scaling (self-reported; thresholds unpublished). https://s3.amazonaws.com/startupcompass-public/StartupGenomeReport2_Why_Startups_Fail_v2.pdf
+- Clozd — reps wrong about win/loss reasons >60% of the time; CRM data matched buyer interviews ~15% of the time (vendor data; method not fully published). https://www.clozd.com/blog/5-lies-your-crm-is-telling-you-about-your-buyers
+- Pendo, *2019 Feature Adoption Report* — ~80% of features rarely or never used (615 of Pendo's own accounts; vendor-skewed). https://www.pendo.io/resources/the-2019-feature-adoption-report/
+- Winning by Design — the bowtie model (retention and expansion as first-class growth engines).
+- Reforge — why funnels force siloed ownership and loops compound.
+- HBR — "When Sales and Marketing Aren't Aligned, Both Suffer" (2018).

--- a/docs/why-align.md
+++ b/docs/why-align.md
@@ -113,7 +113,7 @@ The strongest evidence here is peer-reviewed. We lead with the academic work and
 **Retention & loyalty economics**
 
 - Reichheld & Sasser (1990), "Zero Defections: Quality Comes to Services," *HBR* 68(5):105–111 — the origin of the retention-profit idea (firm-specific Bain cases). https://hbr.org/1990/09/zero-defections-quality-comes-to-services
-- Gupta, Lehmann & Stuart (2004), "Valuing Customers," *Journal of Marketing Research* 41(1):7–18 — a 1% improvement in retention ≈ 5% improvement in firm value; retention dominates acquisition. https://doi.org/10.1509/jmkr.41.1.7.25084
+- Gupta, Lehmann & Stuart (2004), "Valuing Customers," *Journal of Marketing Research* 41(1):7–18 — retention dominates acquisition as a value lever. Abstract: *"a 1% improvement in retention, margin, or acquisition cost improves firm value by 5%, 1%, and .1%, respectively."* https://doi.org/10.1509/jmkr.41.1.7.25084
 - Reinartz & Kumar (2002), "The Mismanagement of Customer Loyalty," *HBR* 80(7):86–94 — the counter-weight: across ~16,000 customers, loyalty ≠ profitability. https://hbr.org/2002/07/the-mismanagement-of-customer-loyalty
 
 **Sales ↔ production / operations (S&OP)**


### PR DESCRIPTION
## What & why

Public-facing accuracy pass on `docs/why-align.md` and `docs/operating-model.md`, driven by a primary-source audit (`research/2026-05-27-sales-academic-evidence-audit.md` in LangOptima-General). Each figure is now either verified-primary or labeled as a vendor benchmark; unverifiable ("zombie") figures are fixed or removed.

## Changes

- **"~80% of journey before sales"** → anchored to **CEB/Google 2012 "~57%"** (the citable origin); a new caveat explains the 80% is a conflation with Gartner's "80% of interactions in digital channels" claim.
- **Win/loss "60–85%"** → split into the two real Clozd numbers (>60% wrong; ~15% CRM-vs-interview match across ~1,000 deals), labeled vendor data.
- **"~80% of features unused"** → attributed to **Pendo 2019** (615 of its own accounts).
- **"36% faster"** caveat → corrected to Forrester's actual "36% *more* revenue growth."
- Removed the untraceable "~8% strongly aligned"; labeled the 24%/27%, $1T, 34%-SLA, and NRR figures with their sources.
- **Sources section is now academic-led** — peer-reviewed anchors (Reichheld & Sasser 1990, Gupta/Lehmann/Stuart 2004, Reinartz & Kumar 2002, Homburg 2008, Kotler 2006, Oliva & Watson 2011, Oldroyd/McElheran/Elkington 2011, Gupta/Raj/Wilemon 1986) above a labeled vendor-benchmark block.

No claim was invented; every citation traces to the audit. The "Honest caveats" section is kept and strengthened.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1PWKFRGNrcbVttJdsDCUu)_