### PR TITLE
Add docs/why-brand.md — the demand-creation companion to why-align

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Nothing there is real — delete `demo/` whenever you like.
 | `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (net revenue retention), and the three shared definitions |
 | `docs/methodology.md` | The idea in full: Claude Code as an operating environment |
 | `docs/why-align.md` | The one-page argument: why your whole go-to-market (marketing, sales, product, retention) runs as one system (with sources) |
+| `docs/why-brand.md` | The companion argument: where demand comes from — why ~95% of buyers aren't ready yet, and how brands actually grow (with sources) |
 | `docs/connecting-a-crm.md` | Optional: make an existing CRM the source of truth and project it into `ops/pipeline.md` — don't run two pipelines |
 
 **Skills by function** — the motion is balanced across the bowtie, not just acquisition:

--- a/docs/why-align.md
+++ b/docs/why-align.md
@@ -2,7 +2,7 @@
 
 Most companies run growth as four departments that hand off down a line: marketing generates demand, sales closes it, product builds, customer success keeps the account. The buyer stopped experiencing it that way — they research, buy, adopt, and renew as one continuous relationship, and they don't care about your org chart. That single change is why coordination *across all four* has moved from "nice to have" to a measurable driver of growth.
 
-This kit keeps the whole motion in one repo on purpose. This page is the *why*: why the four belong together, why they drift apart anyway, what "working together closely" actually means, and how to start.
+This kit keeps the whole motion in one repo on purpose. This page is the *why*: why the four belong together, why they drift apart anyway, what "working together closely" actually means, and how to start. Its companion, [`why-brand.md`](why-brand.md), covers where that demand comes from in the first place — why most buyers aren't ready to buy yet.
 
 > The exact percentages below come from a mix of studies and vary by source. The **direction** is well-supported; treat the **magnitudes** as directional, not benchmark-grade.
 

--- a/docs/why-brand.md
+++ b/docs/why-brand.md
@@ -1,0 +1,72 @@
+# Why Most of Your Marketing Is for Buyers Who Aren't Ready Yet
+
+`why-align.md` argues that the four functions belong in one system, and that alignment decides how *efficiently* you convert demand. This page is the other half: where demand actually *comes from*, and why most of it can't be harvested today. If alignment is how you turn demand into revenue, this is how you make sure there's demand to turn.
+
+> The exact percentages below come from a mix of academic and industry studies and vary by source and category. The **direction** is well-supported; treat the **magnitudes** as directional, not benchmark-grade. Sources and honest caveats are at the bottom.
+
+---
+
+## 1. At any moment, almost no one is buying
+
+The uncomfortable starting point for B2B: in many categories only about **5% of potential buyers are in the market right now**. The other ~95% have no live project, no budget cycle open, no reason to reply — yet (the "95-5 rule," Ehrenberg-Bass / LinkedIn B2B Institute). The "5%" is a category-dependent illustration, not a hard constant — longer buying cycles mean a smaller slice in-market at once — but the shape is robust and it changes everything about what marketing is *for*.
+
+If you only ever target the people ready to buy, you're fishing in 5% of the pond, competing with every rival the buyer already remembers. And when one of the 95% finally enters the market, they don't start neutral — they start with whoever they already recall.
+
+## 2. So marketing has two jobs, not one
+
+- **Harvest the ~5% who are in-market** — capture intent, qualify, convert. This is the demand you can measure this quarter: inbound, lead-gen, a sharp ROI case, fast follow-up. It's necessary, and it's where most teams already spend.
+- **Build memory in the ~95% who aren't** — so that when their project starts next quarter or next year, you're already on the shortlist. This is slower, compounding, and almost always under-funded, because its payoff is deferred and harder to attribute.
+
+A team measured only on this quarter's pipeline will starve the second job to feed the first. That's rational in the moment and expensive over years.
+
+## 3. How brands actually grow: be easy to recall, easy to buy
+
+The most replicated findings in marketing science say growth comes from **availability**, not persuasion:
+
+- **Mental availability** — being the brand that comes to mind in a buying situation, built by linking yourself to the many real-world *situations* that trigger your category ("our data's too fragmented to trust the AI's answer"), and carried by **distinctive, consistent brand assets** so the memory is retrievable later.
+- **Physical availability** — being easy to find, evaluate, and buy when the buyer acts.
+
+And the **Double Jeopardy law** (Ehrenberg, Goodhardt & Barwise, *Journal of Marketing*, 1990 — the firmest evidence here) shows smaller brands have *both* fewer buyers *and* slightly lower loyalty: loyalty mostly follows size. The practical consequence is counter-intuitive but well-evidenced: **you grow mainly by reaching more buyers (penetration), not by squeezing more loyalty out of the ones you have.** (Retention still matters enormously for *revenue* — see `why-align.md` on net revenue retention — it just isn't the lever that *grows the brand*.)
+
+## 4. The budget that does both
+
+How much to each job? The IPA's analysis of ~1,000 campaigns (Binet & Field) found long-term effectiveness is maximized at roughly **60% brand-building / 40% sales activation** — shifting toward about **50:50 for B2B**. And **share of voice** matters: spending a greater share of category voice than your share of market tends to grow share over time (with independent peer-reviewed support). For a small company "share of voice" isn't ad spend — it's consistent, useful presence in the conversations where your category lives.
+
+One more humbling number: the measured effect of advertising on near-term sales is *small* (a meta-analysis puts the average short-run elasticity around 0.12). You can't out-shout a weak offer. The compounding comes from doing the unglamorous thing consistently for years, not from one big campaign.
+
+## 5. What this means for a one-repo go-to-market
+
+The kit is built to keep the whole motion in one place — which is exactly what lets you run *both* jobs without one starving the other:
+
+- **Harvest** lives on the left side of the bowtie: `lead-qualify`, `meeting-prep`, `follow-up`, `cold-outreach` in `ops/pipeline.md`.
+- **Build** is mostly consistency over time: `content-repurpose` to turn every win and idea into presence tied to the situations that trigger your category, kept in git so it compounds with a visible history instead of evaporating in a feed.
+- **The feedback loops keep it honest:** `marketing-feedback` (sales → marketing) tells you the *real language* buyers use and which situations actually trigger them — that's your raw material for building memory in the 95%.
+
+You don't need a brand budget to start. You need a deliberate decision that *some* of the work serves the buyers who aren't ready yet, and a place to keep it consistent.
+
+## 6. A starter checklist
+
+- [ ] **Name your category entry points.** Write down the 5–10 real situations in which someone realizes they have the problem you solve. These are what your "build" content attaches to.
+- [ ] **Pick one distinctive asset and keep it.** A consistent visual and a repeatable verbal hook beat a clever new look every quarter — recall is the whole point.
+- [ ] **Split the work, even 90:10 at first.** Decide what share of effort serves the out-of-market 95%. Anything above zero beats the default.
+- [ ] **Mine the feedback loop for language.** Use what sales actually hears (`marketing-feedback`) as the words your content uses.
+- [ ] **Measure being-remembered, not just replies.** For the 95%, a low immediate reply rate is expected; the win is being recalled when the trigger fires.
+
+## 7. Honest caveats
+
+- **The percentages are soft and sponsor-interested.** The 95-5 ratio is a category-dependent illustration, not a measured constant. The 60:40 / 50:50 splits come from the IPA databank, which over-represents award-winning, larger-budget campaigns (selection bias) — and the field isn't unanimous (Byron Sharp publicly disputes the 60:40 framing). The B2B "50:50" rests on a small sample. Industry sources here (LinkedIn B2B Institute, IPA) have a commercial interest in "do more marketing."
+- **The strongest evidence is the boring law, not the headline number.** Double Jeopardy (penetration over loyalty) is the part that's been replicated for decades; treat it as load-bearing and the budget ratios as directional.
+- **It matters most in considered B2B with long cycles.** For impulse or one-off purchases, the "build for later" argument is weaker.
+- **This is not an argument against harvesting.** Both jobs are necessary. The point is that a one-repo, founder-led motion defaults to ~100% harvest, and that's a long-term tax — not that lead-gen is wrong.
+
+---
+
+## Sources
+
+- **95-5 rule** — J. Dawes, Ehrenberg-Bass Institute / LinkedIn B2B Institute (2021): most B2B buyers are not in-market at any one time.
+- **Double Jeopardy law** — Ehrenberg, Goodhardt & Barwise, "Double Jeopardy Revisited," *Journal of Marketing* (1990); B. Sharp, *How Brands Grow* (OUP, 2010) — penetration over loyalty; mental & physical availability.
+- **Distinctive assets / Category Entry Points** — J. Romaniuk, *Building Distinctive Brand Assets* (OUP, 2018); Romaniuk & Sharp, *How Brands Grow 2* (OUP, 2016).
+- **60:40 split & Excess Share of Voice** — Binet & Field, *The Long and the Short of It* (IPA, 2013); ~50:50 for B2B in the LinkedIn B2B Institute work (2019/2021). Peer-reviewed ESOV support: Danenberg, Kennedy, Beal & Sharp, *Journal of Advertising* (2016).
+- **Advertising elasticity ~0.12** — Sethuraman, Tellis & Briesch, *Journal of Marketing Research* (2011) — the average near-term sales effect of advertising is small.
+
+*A fuller, provenance-graded version of this evidence (with the zombie stats it deliberately avoids) backs the internal operating model. This page keeps the magnitudes directional on purpose.*


### PR DESCRIPTION
## Summary

Adds a public, sourced companion to `docs/why-align.md`. Where `why-align` explains how to *convert and align* demand, **`why-brand.md` explains where demand comes from**:

- The **95-5 reality** — at any moment most B2B buyers aren't in-market, so most marketing has to build memory for later, not harvest intent now.
- **How brands actually grow** — mental & physical availability and penetration (the Double Jeopardy law), not loyalty.
- **The brand-vs-activation budget split** (60:40 B2C / ~50:50 B2B, ESOV) and the humbling ~0.12 advertising elasticity.
- **How it maps to the kit** — harvest on the left of the bowtie, build via `content-repurpose`, language mined from `marketing-feedback`.

Matches `why-align`'s register: magnitudes kept **directional**, an honest-caveats section, and a sources list. Public academic/industry sources only — **no proprietary data, pricing, or PII** (scrub-checked clean).

Also: one row added to the README docs table, and a one-line cross-reference from `why-align.md`.

## Test plan

- [ ] Render `docs/why-brand.md` and confirm links resolve and tone matches `why-align.md`
- [ ] Confirm README docs table renders with the new row
- [ ] Edwin's call on whether the demand-side argument belongs in the public open-core narrative (it rounds out the "we run the whole motion" story)

https://claude.ai/code/session_015dbo9hk9rPc1ooe63MEb8A

---
_Generated by [Claude Code](https://claude.ai/code/session_015dbo9hk9rPc1ooe63MEb8A)_