### PR TITLE
Tighten stat sourcing in why-align (public)

### DIFF
--- a/docs/why-align.md
+++ b/docs/why-align.md
@@ -22,15 +22,15 @@ So the seams a buyer feels aren't only between marketing and sales. They're betw
 
 **Aligning sales and marketing already pays — that's the part most people have heard:**
 
-- SiriusDecisions (now Forrester) benchmarked roughly 400 B2B organizations: tightly aligned sales and marketing achieved **~24% faster three-year revenue growth and ~27% faster profit growth** — the most credible single figure in the literature.
-- IDC estimates the inability to align costs **10%+ of revenue per year**; broader estimates of revenue lost to siloed data and functions run **20–30%**. LinkedIn's "Art of Winning" puts the US aggregate near **$1 trillion a year**.
+- The solid part is peer-reviewed: across studies, the *quality* of the sales–marketing interface is positively associated with business performance (Homburg, Jensen & Krohmer, *Journal of Marketing*, 2008; Le Meunier-FitzHugh & Piercy, 2007) — though the effect is conditional, not automatic (Troy et al., 2008). The most *traceable* benchmark number is Aberdeen's 2010 study of 453 organizations, where the aligned "Best-in-Class" averaged **~20% annual revenue growth versus a ~4% decline** for laggards — read it as correlation among top performers, not proof. A widely repeated SiriusDecisions figure (**~24% faster revenue / ~27% faster profit growth**) circulates without a published methodology, so treat it as illustration rather than evidence.
+- A cost-of-misalignment figure of **~10% of revenue per year** is widely attributed to IDC, with broader "revenue lost to silos" estimates around **20–30%** — both are directional. (The original IDC report is hard to locate, and a circulating "$1 trillion a year" aggregate traces only to recent vendor PR, so don't lean on either precise number.)
 - A concrete waste line: **60–70% of the content marketing produces is never used by sales.**
 
 **The bigger, less-told leak is on the right side of the bowtie:**
 
 - **Net revenue retention is the valuation number.** Median NRR sits around **~106%** (higher for enterprise, lower for SMB). Below 100% means every dollar of acquisition spend is filling a leaking bucket — you grow by running faster, not by compounding.
 - **Premature scaling is the #1 startup killer.** Studies of high-growth startups attribute roughly **70%+ of failures** to scaling before the motion works — pouring acquisition into a product or post-sale experience that can't hold it.
-- **The feedback that would fix it gets lost.** Sales reps **misdiagnose why deals are won or lost 60–85% of the time**, so the real reason rarely reaches marketing or product. And an often-cited rule of thumb is that **~80% of shipped features go rarely or never used** — product building without the signal from the field and the customer base.
+- **The feedback that would fix it gets lost.** Win-loss vendors find that reps and CRM fields capture the real win/loss reason only a minority of the time (Clozd compared 1,000 deals' CRM "closed-lost" reasons to buyer interviews and found they matched ~15% of the time), so the real reason rarely reaches marketing or product. And a vendor rule of thumb (Pendo, across ~615 products) is that **~80% of features are rarely or never used** — treat the exact figure as directional.
 
 Put together: the cost of misalignment isn't only the deals marketing and sales fumble between them. It's the renewals product never hears about and the expansions customer success never triggers.
 
@@ -89,21 +89,33 @@ You don't need everything on day one. A shared definition, a Won→onboarding ha
 
 ## 7. Honest caveats
 
-- **The exact percentages are soft.** Several of the most-quoted figures come from older or vendor-sponsored studies and vary between sources. Use them to make the case, not as guarantees. (One widely repeated "aligned orgs grow 36% faster" line is untraceable to a primary source — the 24% Forrester figure is the defensible one.)
+- **The exact percentages are soft.** Several of the most-quoted figures come from older or vendor-sponsored studies and vary between sources. Use them to make the case, not as guarantees. (The widely repeated "aligned orgs grow 36% faster" line is untraceable to a primary source; even the SiriusDecisions "24%" circulates without a published method. The defensible evidence is the peer-reviewed interface and retention work cited below, plus Aberdeen's traceable n=453 benchmark.)
 - **Correlation isn't proof of causation.** Well-run companies tend to do both alignment *and* growth well, so some of the effect is selection. Treat alignment as necessary, not single-handedly sufficient.
 - **It matters most in considered B2B sales with real post-sale relationships** — long journeys, multiple stakeholders, renewals and expansion. For low-consideration or one-off purchases, the right-side payoff is smaller.
 
 ---
 
-## Sources
+**Peer-reviewed (the solid foundation):**
 
-- Gartner — 67% prefer a rep-free experience; ~80% of the journey before sales; RevOps guidance
-- Forrester / SiriusDecisions — the ~24% alignment economics; the 82%/65% perception gap; ~8% strongly aligned
-- IDC — cost of misalignment (10%+ of revenue/yr); revenue lost to silos (20–30%)
-- LinkedIn "Art of Winning" — the ~$1 trillion aggregate figure
-- Winning by Design — the bowtie model (retention and expansion as first-class growth engines)
-- ChartMogul / SaaS benchmarks — net revenue retention medians (~106%)
-- Startup Genome — premature scaling as the leading cause of high-growth startup failure
-- Clozd — reps misdiagnose win/loss reasons 60–85% of the time
-- Reforge — why funnels force siloed ownership and loops compound
+- Homburg, Jensen & Krohmer (2008), "Configurations of Marketing and Sales: A Taxonomy," *Journal of Marketing* 72(2) — https://journals.sagepub.com/doi/10.1509/jmkg.72.2.133
+- Le Meunier-FitzHugh & Piercy (2007), "Does Collaboration Between Sales and Marketing Affect Business Performance?" *JPSSM* 27(3) — https://ueaeprints.uea.ac.uk/id/eprint/21246/
+- Troy, Hirunyawipada & Paswan (2008), cross-functional integration is *conditional*, *Journal of Marketing* 72(6)
+- Gupta, Lehmann & Stuart (2004), "Valuing Customers" (retention ≈ 5× the next value lever), *JMR* 41(1) — https://business.columbia.edu/sites/default/files-efs/pubfiles/534/Valuing_Customers--JMR_2003.pdf
+- Reichheld & Sasser (1990), "Zero Defections," *HBR* — https://www.bain.com/insights/zero-defections-quality-comes-to-services-harvard-business-review-hbr/
+- Keiningham et al. (2007), peer-reviewed NPS critique, *Journal of Marketing* 71(3) — https://journals.sagepub.com/doi/10.1509/jmkg.71.3.039
+
+**Industry benchmarks & analyst (directional — methodologies vary, some proprietary):**
+
+- Aberdeen Group (2010) — aligned "Best-in-Class" ~20% growth vs ~4% decline (n=453)
+- Gartner — 67% prefer a rep-free experience; ~80% of the journey before sales; "75% of high-growth firms will run RevOps by 2025" (a prediction)
+- Forrester / SiriusDecisions — the ~24% alignment figure (no published method); the 82%/65% perception gap; ~8% strongly aligned
+- IDC — cost of misalignment (~10% of revenue/yr; original report hard to locate)
+- ChartMogul / SaaS Capital — net revenue retention medians (~102–106%, scales with deal size)
+- Pendo (2019) — ~80% of features rarely/never used (~615 products); cf. Standish (2002), critiqued by Mike Cohn
+- Clozd / Anova — reps and CRM capture the real win/loss reason a minority of the time
+- Startup Genome — premature scaling as a leading cause of high-growth startup failure
+- Winning by Design — the bowtie model; Reforge — funnels vs. compounding loops
+
+**Practitioner / press:**
+
 - HBR — "When Sales and Marketing Aren't Aligned, Both Suffer" (2018)


### PR DESCRIPTION
## Summary

`docs/why-align.md` is the public, MIT-licensed argument for running GTM as one system — a data-literate reader will check its numbers. This tightens the sourcing without changing the thesis:

- **Leads with the peer-reviewed evidence** (Homburg/Jensen/Krohmer 2008; Le Meunier-FitzHugh & Piercy 2007; Troy et al. 2008 on conditionality; Gupta et al. 2004; Reichheld & Sasser 1990; Keiningham et al. 2007) — with links.
- **Demotes the SiriusDecisions "24%/27%"** from "the most credible single figure in the literature" to an illustrative vendor figure (it has no published methodology), and swaps in the **traceable Aberdeen n=453** benchmark with a correlation caveat.
- **Drops the "$1 trillion/year"** line (traces only to recent vendor PR).
- **Attributes win-loss and feature-usage precisely** — Clozd's actual finding (CRM vs. buyer interviews matched ~15% of 1,000 deals) instead of the fused "60-85%"; Pendo's ~615-product "~80% of features" instead of the debunked Standish version.
- Rebuilds the **Sources** list into Peer-reviewed / Benchmark / Practitioner tiers.

Full provenance and verdicts: see `research/revenue-evidence-and-stat-audit-2026-05-27.md` in LangOptima-General (PR #145).

## Note
The identical `claude-code-ops-starter/docs/why-align.md` source copy in LangOptima-General gets the same edits in that repo's branch.

https://claude.ai/code/session_01TyVai1esFyr3GC4vx33svd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyVai1esFyr3GC4vx33svd)_