### PR TITLE
Install shellcheck via web SessionStart hook so the lint runs in Claude Code sessions

### DIFF
--- a/.claude/hooks/web-bootstrap.sh
+++ b/.claude/hooks/web-bootstrap.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SessionStart — web/remote dependency bootstrap.
+#
+# Runtime is pure bash + python3 (no npm/pip/cargo). The one tool a fresh
+# Claude Code on the web container lacks is shellcheck — the linter CI runs
+# on .claude/hooks/*.sh (see .github/workflows/shellcheck.yml). Without it
+# you can lint the hooks in CI or a local terminal, but not inside a web
+# session. This hook installs it so `shellcheck .claude/hooks/*.sh` runs
+# in-session too, matching CI.
+#
+# Local sessions skip this entirely (CLAUDE_CODE_REMOTE != true) — your own
+# machine already has whatever you installed. Idempotent, non-interactive,
+# and never blocks: a setup failure logs a warning and exits 0 so the
+# session still starts.
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+log() { echo "[web-bootstrap] $*" >&2; }
+
+# Run a command as root when possible (the web container is usually root;
+# fall back to sudo if available). Returns non-zero if neither works.
+run_root() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    return 1
+  fi
+}
+
+ensure_shellcheck() {
+  if command -v shellcheck >/dev/null 2>&1; then
+    log "shellcheck present ($(shellcheck --version 2>/dev/null | awk '/version:/{print $2; exit}'))"
+    return 0
+  fi
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "WARN: no apt-get — cannot install shellcheck; hook linting will not run this session"
+    return 0
+  fi
+  log "shellcheck missing — installing"
+  # Do NOT gate the install on `apt-get update`: some base images ship
+  # third-party PPAs that 403 on update and would abort an `update && install`
+  # chain. Run them independently and let the install pull from the cache.
+  run_root env DEBIAN_FRONTEND=noninteractive apt-get update -y >/dev/null 2>&1 || true
+  run_root env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends shellcheck >/dev/null 2>&1 || true
+  if command -v shellcheck >/dev/null 2>&1; then
+    log "shellcheck installed ($(shellcheck --version 2>/dev/null | awk '/version:/{print $2; exit}'))"
+  else
+    log "WARN: shellcheck install failed — hook linting will not run this session"
+  fi
+}
+
+main() {
+  log "starting web bootstrap"
+  ensure_shellcheck
+  log "done"
+}
+
+main

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,7 @@
     "SessionStart": [
       {
         "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/web-bootstrap.sh" },
           { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }
         ]
       }


### PR DESCRIPTION
## Why

The Growth OS is meant to run inside Claude Code sessions, not just the terminal. The repo's only automated check is `shellcheck .claude/hooks/*.sh` (`.github/workflows/shellcheck.yml`). That check ran in CI and on a local machine, but a fresh **Claude Code on the web** container ships `bash` + `python3` and **not** `shellcheck` — so you couldn't run the project's own lint inside a web session. That's the "works in the terminal, not in a Claude Code session" gap.

## What

- Add `.claude/hooks/web-bootstrap.sh` — a SessionStart hook that installs `shellcheck` in remote (web) sessions only (`CLAUDE_CODE_REMOTE=true`). Idempotent, non-interactive, never blocks (a setup failure logs a warning and exits 0).
- Register it in `.claude/settings.json` **before** `session-start.sh` (dependencies first, then the priorities context).
- Local sessions are unaffected — the hook exits immediately when not remote.

Note: the installer does **not** gate on `apt-get update` succeeding. Some base images carry third-party PPAs that 403 on update; running `update && install` would abort the whole install. The hook runs them independently and pulls `shellcheck` from the package cache.

## Validation (in this web container)

- ✅ Hook execution: removed `shellcheck`, ran the hook → reinstalled `shellcheck 0.9.0`, exit 0.
- ✅ Linter: `shellcheck .claude/hooks/*.sh` (the exact CI command) passes clean, including the new hook.
- ✅ Local skip: with `CLAUDE_CODE_REMOTE` unset the hook is a no-op (empty output, exit 0).
- ✅ `settings.json` is valid JSON; `session-start.sh` priorities context still injects in a live session.
- ➖ Test: no test suite in this repo (markdown + bash); the hooks executing + the shellcheck lint are the checks.

## Hook execution mode

Synchronous. Pro: shellcheck is guaranteed present before the session starts. Con: web session start waits for the install to finish. Can switch to async if faster startup is preferred.

Once merged to the default branch, all future web sessions will use it.

https://claude.ai/code/session_011taaKvbEjHgCZthZLDKUU6

---
_Generated by [Claude Code](https://claude.ai/code/session_011taaKvbEjHgCZthZLDKUU6)_