### PR TITLE
Pin explicit effort level for Opus 4.8 default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "effortLevel": "high",
   "permissions": {
     "allow": [
       "Read",


### PR DESCRIPTION
## Summary
Makes `effortLevel: "high"` explicit in the starter kit's `settings.json` so behavior is stable across model versions. Opus 4.8 defaults to `high`; the value falls back gracefully on Sonnet (the Pro-tier default). Kept minimal — no privacy/telemetry env opinions imposed on downstream users of this public starter.

Part of the cross-repo Opus 4.8 optimization (see the LangOptima-General PR for full rationale).

## Test Plan
- [x] `settings.json` parses as valid JSON

https://claude.ai/code/session_01T1xFeBZn7kXUP2X74CsQEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1xFeBZn7kXUP2X74CsQEp)_