### PR TITLE
Add Voss labeling + calibrated questions to meeting-prep skill

### DIFF
--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -10,12 +10,35 @@ Before a meeting, build a one-screen brief:
 1. **Who's in the room** and what each likely cares about.
 2. **Where this sits** — pull from `ops/pipeline.md` and any prior notes: last contact, open threads, commitments outstanding.
 3. **Your one goal** for the meeting, and the single decision you want out of it.
-4. **Three questions to ask** — open, not leading.
-5. **The one risk or objection** to be ready for.
+4. **The questions to ask** — labels + calibrated questions (see below).
+5. **The one risk or objection** to be ready for — name it first, before they raise it.
 
 Pull context from `ops/` and the relevant meeting notes; don't invent attendees or history you weren't given.
 
+## Asking the right kind of questions (Chris Voss, *Never Split the Difference*)
+
+The questions decide the meeting. Two moves do most of the work:
+
+- **Label, then ask.** Name the thing they're likely feeling before you question it: *"It seems like…"* / *"It sounds like…"* Then stop talking and let them respond. A label lowers the guard; the silence pulls out the real answer.
+- **Calibrated questions** start with **What** or **How** — never "why" (which sounds like an accusation), never yes/no (which closes things down). They make the other person do the thinking and hand you the information.
+
+Load **3–5** calibrated questions for the meeting. A reusable set:
+
+- *"What's the hardest part of that for your team right now?"*
+- *"How does that show up in your week?"*
+- *"What have you already tried that didn't work the way you hoped?"*
+- *"What does that cost you today?"* (time, rework, decisions made on partial information)
+- *"How would you know this had been solved?"*
+- *"How does a decision like this usually get made on your side?"* — surfaces the real process and who else matters
+- *"What would need to be true for this to be worth doing?"*
+
+**Close two ways:**
+- A **summary they confirm** — play their situation back so well they say *"that's right."* (Not *"you're right,"* which usually means *let's wrap up.*)
+- The **one question that surfaces the hidden thing**: *"Is there anything I should know that I haven't asked about?"*
+
+**Replace on sight:** "Why are you still using X?" → *"What's kept X in place?"* · "Do you have a process for X?" → *"How do you handle X today?"* · "Is that a problem?" → *"What does that cost you?"* · "Would you agree that…?" → delete it.
+
 ## Depth
-- quick: the goal + three questions.
-- standard: the full brief above.
-- deep: + a likely-objections list and a fallback ask if the main one stalls.
+- quick: the goal + one label + three calibrated questions.
+- standard: the full brief above, with the label + 3–5 calibrated questions and a summary-to-confirm.
+- deep: + a likely-objections list (named first, before they raise them), a fallback ask if the main one stalls, and the hidden-thing question to close.


### PR DESCRIPTION
## Summary

Upgrade the public starter-kit `meeting-prep` skill's question guidance with Chris Voss's labeling and calibrated (What/How) questions, from *Never Split the Difference*. Kept generic and self-contained — no internal LangOptima/MEDDPICC/pricing content (this is the MIT giveaway).

### What changed
`.claude/skills/meeting-prep/SKILL.md` — the "questions to ask" step now teaches:
- **Label, then ask** — *"It seems like… / It sounds like…"* then silence.
- **Calibrated What/How questions** (never "why", never yes/no) with a reusable set: hardest part, how it shows up, what it costs today, how the decision gets made, what would need to be true.
- **Two closes** — a summary they confirm with *"that's right"* (vs. *"you're right"*), and the hidden-thing question *"Is there anything I should know that I haven't asked about?"*
- **Replace-on-sight list** for why/yes-no phrasings.
- Depth modes (quick/standard/deep) updated to match.

## Test plan
- Invoke the `meeting-prep` skill → output includes a label, 3–5 calibrated questions, and a summary-to-confirm.
- Confirm no internal/proprietary terms leaked (generic register only).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnjYe7KNjBb75CUTYv7Rv2)_