### PR TITLE
Document the web-bootstrap hook; sync README docs and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Principles from science** (`docs/principles-from-science.md`) — twenty-one
+  portable operating principles drawn from seven sciences, each with two sourced
+  quotes and a worked go-to-market example; linked from the README docs table. (#26)
+- **Web-session bootstrap hook** (`.claude/hooks/web-bootstrap.sh`) — a
+  SessionStart hook that installs `shellcheck` in remote / Claude-Code-on-the-web
+  containers only, so the hook lint (`.github/workflows/shellcheck.yml`) also runs
+  in-session. Skipped locally, idempotent, and non-blocking. (#23)
+- **Demand-side argument** (`docs/why-brand.md`) — the companion to `why-align`:
+  where demand comes from (the 95-5 reality, mental & physical availability, the
+  brand-vs-activation split), with sources. (#21)
+- **Fictional starter data in `ops/`** — the operating books now ship seeded with
+  a coherent set of fictional accounts (pipeline, customers, daily log, feedback
+  log, roadmap signals) so the rituals run against realistic data out of the box.
+  (#15, #16)
 - **Connecting-a-CRM guide** (`docs/connecting-a-crm.md`) — an optional pattern
   for making an existing CRM the system of record and projecting it into
   `ops/pipeline.md`, so you never run two pipelines. (#12)
@@ -19,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`meeting-prep` skill** (`.claude/skills/meeting-prep/SKILL.md`) — question
+  guidance upgraded with Chris Voss labeling and calibrated What/How questions
+  (label-then-ask, the two closes, a replace-on-sight list for why/yes-no). (#25)
+- **Explicit effort level** (`.claude/settings.json`) — pins `effortLevel: "high"`
+  so behavior is stable across model versions (Opus 4.8 default; degrades
+  gracefully on Sonnet). (#24)
+- **Tightened stat sourcing** in `docs/why-align.md` and `docs/operating-model.md`
+  — a primary-source audit reframed unverifiable vendor figures as directional,
+  led with peer-reviewed evidence, corrected the win-loss and feature-usage
+  attributions, and rebuilt the Sources list into tiers. (#17, #18, #19, #20, #22)
 - **Commit secret-guard** (`.claude/hooks/pre-commit-guard.sh`) — broadened to
   catch GitHub fine-grained PATs and OAuth/server tokens, Google API keys, and
   Stripe live keys, with the covered formats documented inline. (#8)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This project uses Claude Code as a go-to-market operating environment — market
 
 Guardrails run on events, not memory (`.claude/hooks/`):
 
-- **SessionStart** surfaces `ops/priorities.md`.
+- **SessionStart** surfaces `ops/priorities.md`. On remote / Claude-Code-on-the-web sessions only, a bootstrap step (`web-bootstrap.sh`) also installs the hook linter (`shellcheck`) so you can lint the hooks in-session, matching CI; it's skipped locally and never blocks.
 - **PreCompact** re-injects priorities + the latest log entry so long sessions don't lose the thread.
 - **PreToolUse(Edit|Write)** blocks writes to secrets, keys, and `.env`.
 - **Stop** nudges you to `/end-of-day` until today is logged.

--- a/README.md
+++ b/README.md
@@ -54,15 +54,16 @@ Nothing there is real — delete `demo/` whenever you like.
 
 | Piece | What it is |
 |---|---|
-| `.claude/hooks/` | Five guardrails: session-start context, **state re-injection across compaction**, a **commit secret-guard**, sensitive-file protection, an end-of-day nudge |
+| `.claude/hooks/` | Five guardrails: session-start context, **state re-injection across compaction**, a **commit secret-guard**, sensitive-file protection, an end-of-day nudge — plus a **web-session bootstrap** that installs the hook linter (`shellcheck`) on remote / Claude-Code-on-the-web containers |
 | `.claude/commands/` | Daily rituals you invoke by name: `/morning-briefing`, `/midday-checkin`, `/end-of-day`, `/weekly-review`, plus `/demo-briefing` |
 | `.claude/skills/` | Skill templates grouped by the four growth functions (see below) — so the balance across marketing, sales, product, and retention is visible, not acquisition-only |
-| `ops/` | Your plain-text playbooks — `priorities.md`, `daily-log.md`, `pipeline.md` (left side), `customers.md` and `roadmap-signals.md` (right side). Start here. |
+| `ops/` | Your plain-text playbooks — `priorities.md`, `daily-log.md`, `pipeline.md` (left side), `customers.md` and `roadmap-signals.md` (right side), and `feedback-log.md` (the shared cross-function loop). Start here. |
 | `demo/` | A fictional pipeline *and* customer book so you can see the whole motion work (and present from it safely) |
 | `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (net revenue retention), and the three shared definitions |
 | `docs/methodology.md` | The idea in full: Claude Code as an operating environment |
 | `docs/why-align.md` | The one-page argument: why your whole go-to-market (marketing, sales, product, retention) runs as one system (with sources) |
 | `docs/why-brand.md` | The companion argument: where demand comes from — why ~95% of buyers aren't ready yet, and how brands actually grow (with sources) |
+| `docs/principles-from-science.md` | A thinking aid: twenty-one operating principles drawn from seven sciences (leverage, momentum, entropy…) — each with two sourced quotes and a worked go-to-market example |
 | `docs/connecting-a-crm.md` | Optional: make an existing CRM the source of truth and project it into `ops/pipeline.md` — don't run two pipelines |
 
 **Skills by function** — the motion is balanced across the bowtie, not just acquisition:
@@ -100,6 +101,7 @@ The left side lives in `ops/pipeline.md`; the right side in `ops/customers.md` (
 - **`pre-commit-guard.sh`** blocks a commit if staged changes look like they contain a secret (API keys, private keys, tokens).
 - **`protect-files.sh`** stops the agent writing to `.env`, keys, and credentials.
 - **`session-start.sh`** and **`stop-reminder.sh`** open and close the day.
+- **`web-bootstrap.sh`** runs only in remote / Claude-Code-on-the-web sessions (`CLAUDE_CODE_REMOTE=true`) and installs the one tool a fresh web container lacks — `shellcheck` — so you can lint the hooks in-session, matching CI. Skipped on your own machine, idempotent, and never blocks: a setup failure just logs a warning.
 
 All pure bash (one uses `python3` to read a payload). No API keys, no MCP — it runs anywhere out of the box.
 

--- a/docs/why-align.md
+++ b/docs/why-align.md
@@ -58,7 +58,7 @@ Goodwill can't out-run a broken incentive system. If you want different behavior
 
 Not constant meetings or a merged org chart — a small set of shared structures. The same handful that aligns sales and marketing extends to all four:
 
-1. **Shared definitions, written once.** One ICP. One MQL→SQL bar both sales and marketing own. One **Won→onboarding handoff** so a signed deal doesn't drop silently into a CS void. (Only ~8% of B2B firms even share an MQL/SQL definition; firms with documented SLAs are ~34% more likely to see higher YoY ROI.)
+1. **Shared definitions, written once.** One ideal customer profile (ICP). One MQL→SQL bar — marketing-qualified to sales-qualified lead — that both sales and marketing own. One **Won→onboarding handoff** so a signed deal doesn't drop silently into a CS void. (Only ~8% of B2B firms even share an MQL/SQL definition; firms with documented SLAs are ~34% more likely to see higher YoY ROI.)
 2. **Two-way commitments (SLAs).** Marketing commits to lead volume *and quality*; sales commits to follow-up speed *and honest feedback*; sales commits to a complete handoff at won; CS commits to flag risk early (the renewal motion starts day 60, not day 85).
 3. **Shared goals — one revenue number.** A North Star that captures customer value, with **NRR** as the financial number the whole bowtie rolls up to. Not four separate local targets that pull apart.
 4. **One source of truth.** A shared system with closed-loop reporting, so all four reason from the same numbers.


### PR DESCRIPTION
## Summary

Documentation drift swept up after the recent batch of merges. Docs only — no behaviour change.

- **Documents the `web-bootstrap.sh` hook.** The remote/web SessionStart hook (installs `shellcheck` so the hook lint runs in-session, matching CI) was wired in `.claude/settings.json` (#23) but missing from the README hooks table, the "hooks earn their place" section, and `CLAUDE.md`. Now described in all three, framed as a setup hook (skipped locally, idempotent, non-blocking) rather than a guardrail.
- **README inventory gaps.** Adds the orphaned `docs/principles-from-science.md` to the docs table (nothing linked to it) and lists `ops/feedback-log.md` (the shared cross-function loop) in the ops row.
- **CHANGELOG backfill.** `[Unreleased]` was missing everything merged since #12. Added: why-brand (#21), principles-from-science (#26), web-bootstrap (#23), ops seed data (#15/#16), the `meeting-prep` Voss upgrade (#25), the `effortLevel` pin (#24), and the why-align stat-sourcing pass (#17–#22).

## Test plan

- [ ] README, CLAUDE.md, and CHANGELOG render; the new hook bullet and docs-table row read correctly.
- [ ] All internal doc links still resolve.

https://claude.ai/code/session_01Cgq1wXMedbRUjJYRMfRYRk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cgq1wXMedbRUjJYRMfRYRk)_