### PR TITLE
Add docs/principles-from-history.md (Churchill via The Last Lion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Nothing there is real — delete `demo/` whenever you like.
 | `docs/why-align.md` | The one-page argument: why your whole go-to-market (marketing, sales, product, retention) runs as one system (with sources) |
 | `docs/why-brand.md` | The companion argument: where demand comes from — why ~95% of buyers aren't ready yet, and how brands actually grow (with sources) |
 | `docs/principles-from-science.md` | A thinking aid: twenty-one operating principles drawn from seven sciences (leverage, momentum, entropy…) — each with two sourced quotes and a worked go-to-market example |
+| `docs/principles-from-history.md` | A companion thinking aid: operating principles drawn from history and biography (Churchill, via Manchester's *The Last Lion*) — each with a verified, sourced quote, a worked go-to-market example, and an apocrypha-screening note |
 | `docs/connecting-a-crm.md` | Optional: make an existing CRM the source of truth and project it into `ops/pipeline.md` — don't run two pipelines |
 
 **Skills by function** — the motion is balanced across the bowtie, not just acquisition:

--- a/docs/principles-from-history.md
+++ b/docs/principles-from-history.md
@@ -1,0 +1,51 @@
+# Principles from history, applied to go-to-market
+
+History's operators left a usable manual. Stripped to their load-bearing ideas, the lives of people who built, led, and endured under pressure turn out to be operating principles in costume — the same leverage, momentum, and resilience the [science companion](principles-from-science.md) draws from physics and biology.
+
+This page is the first installment, drawn from one well-documented life: Winston Churchill, as told in William Manchester's biography *The Last Lion* (Vol. 1 *Visions of Glory*; Vol. 2 *Alone*; Vol. 3 *Defender of the Realm*, completed by Paul Reid). Each principle has a plain-language explanation, a **verified, attributed quote**, and a short worked go-to-market example. They're a thinking aid for anyone running a motion in this kit — not prescriptive, not brand-specific. **Bring your own sources; this is a pattern to copy.**
+
+> **On sourcing — Churchill is the most misquoted man in the language.** Every quote below was checked against the [International Churchill Society](https://winstonchurchill.org) and the Churchill Project (Hillsdale College). The popular fakes are excluded on principle: *"Success is going from failure to failure without loss of enthusiasm,"* *"Success is not final, failure is not fatal…,"* and *"If you're going through hell, keep going"* have **no source** in the 2.5M+ words by and about Churchill — do not repeat them. The same discipline applies to every figure: an inspiring quote you can't source is a liability, not an asset. (*"He mobilized the English language and sent it into battle"* is Edward R. **Murrow** about Churchill — not Churchill's own line.)
+
+---
+
+## Conviction
+
+**Solitary foresight — be right before it's popular, on an earned read.** Manchester's striking claim is that Churchill's finest hour was the 1930s "wilderness," not the war: out of office and mocked as a warmonger, he warned of German rearmament and was vindicated by events, not by consensus. The detail that makes it operating advice: he ran a private intelligence network and had *better data than the government.* Foresight was earned, then defended — the opposite of stubbornness.
+> "Never give in, never give in, never, never, never, never—in nothing, great or small, large or petty—never give in except to convictions of honour and good sense." — **Winston Churchill**, Harrow School, 29 October 1941.
+**Example:** A contrarian channel bet (the channel everyone says is dead) is only worth holding if you've done more homework than the doubters. Earned conviction is an asset; posture dressed as conviction burns budget. Do the homework, then stop seeking permission.
+
+**Keep going through the dip.** Compounding looks like failure right up until it doesn't. Churchill's private wartime shorthand for the daily discipline of continuing was "KBO."
+> "We must just KBO," which, he explained, meant "Keep Buggering On." — **Winston Churchill**, to his private secretary, December 1941 (recorded by John Peck).
+**Example:** Outbound and content are flywheels — little visible return for weeks, then sudden. The operator who KBOs through the quiet stretch outlasts the one who reads an empty first month as proof the channel is dead.
+
+---
+
+## Output
+
+**Engineer your energy, not just your time — and recover actively.** Churchill's output was prodigious and ran on a *designed* daily system: morning work from bed, a disciplined afternoon nap he said gave him two working days inside one, dictation to relays of secretaries. Against depression he used not idleness but a change of muscle — painting and bricklaying.
+> "I have had a delightful month building a cottage and dictating a book: 200 bricks and 2,000 words a day." — **Winston Churchill**, on his time at Chartwell, September 1928.
+**Example:** Treat energy as the binding constraint. Put the hardest cognitive work (positioning, pricing, narrative) in your peak window and protect a real recovery block — it's not slack, it's what creates the second shift. When depleted, switch muscles rather than grinding a tired brain through a pipeline review.
+
+**Bias to action.** Churchill governed by a flow of short, dated minutes and reserved a bright printed label — **ACTION THIS DAY** — for the few things that genuinely couldn't wait. His standing "Brevity" memo to the War Cabinet (1940) ordered officials to compress reports to their essential points so decisions could be made fast. *(Both are documented practice from the Churchill Archives — described here, not quoted, to avoid putting non-verbatim words in his mouth.)*
+**Example:** A leader's scarcest export is momentum; most deals die of slow no's, not bad ones. Keep an "Action This Day" list to a true few and force them today — the label only works because it's rare.
+
+---
+
+## Persuasion & proportion
+
+**Mobilize the words — communication is the work, not the decoration.** In 1940 the speeches held a nation together, and they were not improvised gifts: Churchill laboured roughly an hour over every minute he delivered. A correct decision no one is moved to act on is inert.
+> "He mobilized the English language and sent it into battle." — **Edward R. Murrow**, broadcaster, on Churchill (Murrow's line, *about* Churchill).
+**Example:** The pitch, the launch post, the board update, the renewal conversation are *built artefacts* — drafted, cut, rehearsed — not bolted on after the "real work." Spend the disproportionate hour on the few sentences that must land.
+
+**Magnanimity in victory — win without poisoning the next round.** The moral Churchill placed at the front of his war memoirs is a whole operating philosophy in four words.
+> "In War: Resolution. In Defeat: Defiance. In Victory: Magnanimity. In Peace: Goodwill." — **Winston Churchill**, the moral of *The Second World War* (1948).
+**Example:** The close is the first interaction of the next relationship, not the last of this one. Win the negotiation, then stop — don't run up the score. The reference, the expansion, and the renewal all live on the other side of magnanimity.
+
+---
+
+## Credits & sources
+
+- William Manchester, *The Last Lion: Winston Spencer Churchill*, Vols. 1–2; Manchester & Paul Reid, Vol. 3.
+- Quote verification: the International Churchill Society (winstonchurchill.org) and the Churchill Project, Hillsdale College.
+
+This page is a *pattern*, not a canon — copy the format, screen your own quotes the same way, and add the figures whose operating lessons you actually use.


### PR DESCRIPTION
## Summary

A public, generic companion to `docs/principles-from-science.md`: operating principles drawn from history, applied to go-to-market, with the same sourcing discipline.

## What's here

- **New `docs/principles-from-history.md`** — operating principles from one well-documented life (Churchill, via Manchester's *The Last Lion*), grouped as conviction · output · persuasion & proportion. Each has a **verified, attributed quote** and a worked go-to-market example, plus a prominent *On sourcing* note that screens the popular Churchill fakes — a reusable apocrypha-screening pattern any operator can copy.
- **`README.md`** — links the new doc from the "What's inside" table.

No private content — fits the repo's "bring your own judgment" chassis philosophy. MIT; sources credited (Manchester; International Churchill Society; the Churchill Project).

## Notes

Draft for review.

https://claude.ai/code/session_01VWyc53tvT2LSvLT1fvRMV9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWyc53tvT2LSvLT1fvRMV9)_