### PR TITLE
Add cloud routines, operating rules, and a CI reliability backstop

### DIFF
--- a/.claude/commands/end-of-day.md
+++ b/.claude/commands/end-of-day.md
@@ -8,8 +8,9 @@ Close out the day:
 
 1. Ask me what got done today (or infer it from `git log` since this morning) — across both sides of the bowtie: deals worked *and* post-sale touches (onboarding steps, adoption nudges, renewal/expansion moves, signals routed to product).
 2. Append a dated entry to `ops/daily-log.md` (newest at the top): shipped, slipped, one thing learned. Log post-sale work alongside deals — a renewal call or an adoption fix counts the same as a deal advanced.
-3. Draft tomorrow's top three into `ops/priorities.md`.
-4. Confirm what you wrote. Keep it tight.
+3. **Persist & reconcile the CRM.** Write the day's stage/score/note changes back per [`.claude/rules/crm-usage.md`](../rules/crm-usage.md), then reconcile the mirror — rewrite `ops/pipeline.md` from the CRM so tomorrow opens consistent. Skip if no CRM is connected.
+4. Draft tomorrow's top three into `ops/priorities.md`.
+5. Confirm what you wrote — and log every CRM write (`object · field · old → new`). Keep it tight.
 
 ## Depth
 - quick: log one line (shipped / slipped) and tomorrow's top item.

--- a/.claude/commands/midday-checkin.md
+++ b/.claude/commands/midday-checkin.md
@@ -10,7 +10,7 @@ A quick reset. In order:
 2. Mark what's done. Flag anything at risk of not happening today.
 3. Name the one thing that must happen this afternoon — and protect time for it. (It can be a deal or a post-sale move — whichever is most at risk of slipping.)
 
-Keep it to a few lines. No recap of things already finished.
+Keep it to a few lines. No recap of things already finished. If a deal moved this morning, persist the stage/score change per [`.claude/rules/crm-usage.md`](../rules/crm-usage.md) — safe writes only.
 
 ## Depth
 - quick: the one thing that must happen this afternoon.

--- a/.claude/commands/morning-briefing.md
+++ b/.claude/commands/morning-briefing.md
@@ -8,12 +8,13 @@ Run my morning ritual, in order:
 
 1. **Priorities.** Read `ops/priorities.md` and list what's still open.
 2. **Yesterday.** Read the most recent entry in `ops/daily-log.md`. Summarize what got done and what's still hanging.
-3. **Field intel → marketing.** Scan the latest `ops/daily-log.md` entry (and any fresh meeting notes) for recurring objections, competitor mentions, missing proof, or win/loss reasons, and surface them as `MARKETING-ACTION` lines so marketing can act — this is what the `marketing-feedback` skill does. Skip if there's nothing new.
-4. **Post-sale read.** Scan `ops/customers.md` for anything that needs attention today: renewals inside 60 days, accounts at 🔴/🟡 (usage down, champion quiet, single-threaded), and adoption stalls (a workflow never turned on). Then surface the top one or two open items in `ops/roadmap-signals.md`. Skip a line if the file is empty.
-5. **Today's top three.** Propose exactly three priorities for today, each with a one-line reason. At least one should move something forward, not just maintain it; lean toward covering both sides of the bowtie when both have live work.
-6. **Offer.** Ask if I want to append today's plan to `ops/daily-log.md`.
+3. **Pipeline.** Read the open pipeline — `ops/pipeline.md`, or a connected CRM per [`.claude/rules/crm-usage.md`](../rules/crm-usage.md) (read-only this run). Flag stalls (no activity in 7+ days), deals closing soon, and qualification red flags. Top-tier first.
+4. **Field intel → marketing.** Scan the latest `ops/daily-log.md` entry (and any fresh meeting notes) for recurring objections, competitor mentions, missing proof, or win/loss reasons, and surface them as `MARKETING-ACTION` lines so marketing can act — this is what the `marketing-feedback` skill does. Skip if there's nothing new.
+5. **Post-sale read.** Scan `ops/customers.md` for anything that needs attention today: renewals inside 60 days, accounts at 🔴/🟡 (usage down, champion quiet, single-threaded), and adoption stalls (a workflow never turned on). Then surface the top one or two open items in `ops/roadmap-signals.md`. Skip a line if the file is empty.
+6. **Today's top three.** Propose exactly three priorities for today, each with a one-line reason. At least one should move something forward, not just maintain it; lean toward covering both sides of the bowtie when both have live work.
+7. **Offer.** Ask if I want to append today's plan to `ops/daily-log.md`.
 
-Keep it short. Lead with the top three. No preamble.
+Keep it short. Lead with the top three. No preamble. Render the to-do list the one canonical way — see [`.claude/rules/todo-single-source.md`](../rules/todo-single-source.md) — and compose the briefing around it; don't re-group it here.
 
 ## Depth
 - quick: just today's top three.

--- a/.claude/commands/weekly-review.md
+++ b/.claude/commands/weekly-review.md
@@ -25,7 +25,7 @@ Run an honest weekly review across the whole motion — both sides of the bowtie
 9. Pick next week's single most important priority and write it to the top of `ops/priorities.md`.
 10. Name one thing to stop doing.
 
-Lead with the summary. Don't pad it. If `ops/customers.md` or `ops/roadmap-signals.md` is empty, say so and skip that section.
+Lead with the summary. Don't pad it. If `ops/customers.md` or `ops/roadmap-signals.md` is empty, say so and skip that section. Reconcile the pipeline mirror against the CRM per [`.claude/rules/crm-usage.md`](../rules/crm-usage.md) — read-only beyond what the daily rituals already persisted.
 
 ## Depth
 - quick: the week's three-line summary, renewals/risks inside 60 days, and next week's one priority.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# SessionStart — surface your priorities the moment a session opens.
-# Pure bash: no API keys, no MCP, runs anywhere. Edit ops/priorities.md to
-# change what shows up here.
+# SessionStart — surface your priorities the moment a session opens, and the
+# freshest cross-function loop signals so they can't go stale silently.
+# Pure bash: no API keys, no MCP, runs anywhere. Edit ops/priorities.md (and
+# ops/feedback-log.md) to change what shows up here.
 
 DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+# Print the newest dated batch of feedback-log signals (the sales<->product
+# loop). Called below as `surface_loop || true`, which suspends `set -e` inside
+# the function, so a missing file or an empty match can never block the session.
+surface_loop() {
+  local feedback="$DIR/ops/feedback-log.md" latest
+  [ -f "$feedback" ] || return 0
+  latest=$(grep -oE '^#{2,}[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}' "$feedback" \
+    | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort -r | head -n1) || return 0
+  [ -n "$latest" ] || return 0
+  echo
+  echo "Open loop — newest signals ($latest), in ops/feedback-log.md:"
+  awk -v d="$latest" '
+    /^##/ { show = (index($0, d) > 0) ? 1 : 0; next }
+    show && /^- / { print "  " $0 }
+  ' "$feedback" | head -n 5
+}
 
 echo "## Session start — $(date '+%Y-%m-%d %H:%M')"
 echo
@@ -14,6 +32,7 @@ if [ -f "$DIR/ops/priorities.md" ]; then
 else
   echo "No ops/priorities.md yet — run /morning-briefing to start the day."
 fi
+surface_loop || true
 echo
 echo "Rituals: /morning-briefing · /midday-checkin · /end-of-day · /weekly-review"
 echo "New here? Run /demo-briefing to see it work on sample data."

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,23 @@
+# Rules — the operating constraints every session honors
+
+A **rule** is a standing constraint on *how* the rituals work — not a task you run,
+but a convention every run respects. Where a command in [`.claude/commands/`](../commands/)
+says *what to do*, a rule says *how to do it safely and consistently*, whether the
+run is you at the keyboard or an unattended [cloud routine](../scheduling/cloud-routines.md).
+
+This matters most when a run is **autonomous**. A cloud routine has no one to ask
+mid-run, so the routine prompt tells it to execute the command "honoring CLAUDE.md
+and the rules in `.claude/rules/`." These files are what that line points at.
+
+| Rule | Governs |
+|---|---|
+| [`crm-usage.md`](crm-usage.md) | Reaching a CRM over MCP — the docs-first access protocol, the three-lane convention, and the write-authority guardrails an unattended run must respect. |
+| [`todo-single-source.md`](todo-single-source.md) | One canonical way the to-do list is queried and rendered, so every entry path (session start, each ritual, each routine) shows the same list. |
+
+## Conventions
+
+- **Generic, like the rest of the kit.** Rules describe a pattern with
+  `<placeholders>`; the specifics (your CRM's API, your field names, your IDs) live
+  in a private skill or a gitignored config, never here.
+- **A rule is the single source of truth for its concern.** Don't restate its logic
+  inside a command or a routine prompt — point to the rule and let it own the detail.

--- a/.claude/rules/crm-usage.md
+++ b/.claude/rules/crm-usage.md
@@ -1,0 +1,110 @@
+# Rule: using a CRM over MCP
+
+**Scope.** This rule governs *how* a session reads and writes a CRM reached through
+an [MCP](../../README.md#make-it-yours) server — the access protocol and the
+write-authority guardrails. The *projection* mechanics (hydrating the CRM into
+[`ops/pipeline.md`](../../ops/pipeline.md), find-or-create, stage-ID mapping,
+paging) live in [`docs/connecting-a-crm.md`](../../docs/connecting-a-crm.md) and
+aren't repeated here. Read that first; this rule is what keeps an **unattended**
+run from doing damage with the access it has.
+
+> Generic by design. Wire the specifics — your CRM's endpoints, field names, and
+> option IDs — into a private skill or gitignored config, never into this repo.
+
+## Three lanes — don't merge them
+
+Three systems each own one kind of truth. Keeping them separate is what stops a
+routine from, say, turning a deal note into a duplicate task.
+
+| Lane | Owns | Example tool |
+|---|---|---|
+| **Task tool** | *What to do* — the to-do list | your task manager (e.g. Notion, Linear) |
+| **Meeting-notes tool → wiki** | *What was said* — transcripts, summaries | your notetaker |
+| **CRM (via MCP)** | *What changed about the deal* — stage, qualification scores, opportunity fields, deal notes | your CRM |
+
+- **Tasks stay single-homed in the task tool.** Routines do **not** create CRM
+  tasks — that forks the to-do list into two places (see
+  [`todo-single-source.md`](todo-single-source.md)).
+- The CRM is the system of record for *deals*; [`ops/pipeline.md`](../../ops/pipeline.md)
+  is a **mirror** of it. On any conflict, the CRM wins and the mirror is rewritten.
+
+## Docs-first access protocol
+
+For a CRM whose MCP server is **documentation-driven** (it exposes its own API docs
+rather than a fixed tool per field), never guess a path. Follow the chain every
+time:
+
+1. **Discover** — list the available docs paths / endpoint families.
+2. **Fetch the schema** — get the exact request/response shape for the one endpoint
+   you need, using only a path returned by step 1.
+3. **Read or write only via discovered paths** — with the parameters and body the
+   schema specified. An API path you didn't get from the docs is a guess; don't
+   send it.
+4. **Resolve a self-scoped identity when needed** — for "my deals / my accounts,"
+   resolve the current-user identity from the server rather than assuming an ID.
+
+Two things bite every time, so make them habits:
+
+- **Resolve select-option IDs from the schema's definitions endpoint on every run.**
+  Pipeline stages, qualification tiers, and other dropdowns are **org-specific** and
+  change. Writing a stage *label* where the API wants an option *ID* fails silently.
+- **Dedup before create.** Search by name first; find-or-create, never blind-create.
+  (The mechanics are in [`connecting-a-crm.md`](../../docs/connecting-a-crm.md).)
+
+## Write-authority guardrails
+
+These exist because a [cloud routine](../scheduling/cloud-routines.md) runs
+**autonomously** — there's no one to catch a bad write mid-run. Every write obeys
+all six:
+
+1. **Read before write.** Fetch the current value first; decide the change against
+   what's actually there, not what you assume is there.
+2. **Append, never overwrite, notes.** Add a dated note; don't replace the deal's
+   note field. The same goes for *many*-relationships (committee members): add,
+   don't replace.
+3. **Log every write as an audit trail.** In the run's output, record each mutation
+   as `object · field · old → new`. An unattended run that can't show what it
+   changed shouldn't have changed it.
+4. **Touch only the fields this routine owns.** A briefing that owns *stage* and
+   *deal note* does not edit *amount* or *close date*. Stay in your lane.
+5. **Never cascade on a CRM failure.** If a write fails, log it, flag the mirror
+   stale, and continue the rest of the run — don't retry-storm and don't let one
+   failed field abort the ritual.
+6. **Treat AI-generated / computed fields as read-only.** Scores or summaries the
+   CRM writes itself are outputs, not inputs you overwrite.
+
+## Choose your write authority
+
+Pick the level you're comfortable handing an autonomous run, and set the MCP
+server's scope (or a private skill's logic) to match:
+
+| Level | What a routine may do | Trade-off |
+|---|---|---|
+| **Read-only** | Read the pipeline; write nothing back | Safest. The mirror in `ops/` and your notes hold all edits; the CRM is never touched by automation. |
+| **Read + safe writes** | Read, plus append notes and set the fields it owns (stage, score) | The recommended default — useful, bounded by the guardrails above. |
+| **Full read-write** | Read and write any field | **Autonomous runs mutate your system of record without review.** Only with the guardrails above and a `Run now` you've audited. |
+
+If unsure, start **read-only**, watch a few `Run now` outputs, then widen.
+
+## Routine wiring
+
+Each ritual touches the CRM in one specific way — and only that way:
+
+- **`/morning-briefing`** — *read* the open pipeline for **stalls** (no activity in
+  N days), deals **closing soon**, and **qualification red flags**. No writes.
+- **`/midday-checkin`** — if a deal moved during the day, *persist* the stage/score
+  change (safe writes only); otherwise read-only.
+- **`/end-of-day`** — *persist* the day's stage/score/note changes, then **reconcile
+  the mirror**: rewrite [`ops/pipeline.md`](../../ops/pipeline.md) from the CRM so
+  tomorrow opens consistent.
+- **`/weekly-review`** — read for the week's movement; reconcile the mirror; write
+  nothing the daily rituals didn't already persist.
+
+## See also
+
+- [`docs/connecting-a-crm.md`](../../docs/connecting-a-crm.md) — the projection loop
+  and the find-or-create / select-ID / paging mechanics this rule assumes.
+- [`todo-single-source.md`](todo-single-source.md) — why deals (CRM) and tasks (task
+  tool) stay in separate lanes.
+- [`../scheduling/cloud-routines.md`](../scheduling/cloud-routines.md) — the
+  autonomous runs these guardrails protect.

--- a/.claude/rules/todo-single-source.md
+++ b/.claude/rules/todo-single-source.md
@@ -1,0 +1,71 @@
+# Rule: one to-do list, rendered one way
+
+**The bug this prevents.** A briefing grows its *own* way of grouping the to-do
+list — "due today," sorted by project — that drifts from how the list is shown at
+session start. Now the same tasks render two different ways depending on how you
+entered, and you can't trust either. The fix is a single canonical render spec that
+every entry path defers to.
+
+This file **is** that spec. It owns *how the to-do list is queried and displayed*.
+Nothing else re-derives it.
+
+## The query + render contract
+
+1. **One source for the list.** The open task set comes from the **task tool**
+   (your task manager, or [`ops/priorities.md`](../../ops/priorities.md) if you
+   haven't connected one) — one place, queried one way.
+2. **Pull the whole open set; don't pre-filter at query time.** Fetch *all* open
+   tasks. Do **not** query for "due today" or "this project" at the source — that
+   filter is exactly what makes two sessions show different lists.
+3. **Derive urgency at render, not at query.** "Due today," "overdue," "top three"
+   are *views* computed from the full set when you display it. Same input set every
+   time → same list every time, whoever's asking.
+4. **Render the same shape everywhere.** Newest/by-due ordering, the same grouping,
+   the same fields — defined once, here.
+
+## Everything defers to this spec
+
+Keep this defer-list current. If you add a path that shows tasks, add it here and
+point it back at this rule rather than letting it grow its own grouping:
+
+- The **SessionStart hook** ([`session-start.sh`](../hooks/session-start.sh)) — what
+  you see when a session opens.
+- [`/morning-briefing`](../commands/morning-briefing.md),
+  [`/midday-checkin`](../commands/midday-checkin.md),
+  [`/end-of-day`](../commands/end-of-day.md),
+  [`/weekly-review`](../commands/weekly-review.md), and
+  [`/demo-briefing`](../commands/demo-briefing.md).
+- **Cloud routines** — the unattended runs of the rituals above
+  ([`../scheduling/cloud-routines.md`](../scheduling/cloud-routines.md)). A routine
+  is the most important entry to keep on this list: it can't notice that its list
+  diverged from yours.
+
+## Routines compose around the list — they never fork it
+
+A ritual adds *context* around the one list; it does not re-render the list:
+
+- **Compose:** wrap the list with the CRM read (deals — via
+  [`crm-usage.md`](crm-usage.md)) and calendar context (what's on today). That's
+  additive.
+- **Don't fork:** never re-group, re-filter, or re-sort the tasks into a second
+  arrangement. The Top 3 a briefing produces is a *derived view*, not a new list.
+
+## Three lanes feed the brief — keep them straight
+
+The same separation as [`crm-usage.md`](crm-usage.md), from the to-do angle:
+
+| Lane | Role in the brief |
+|---|---|
+| **Task tool** | The **list** — the open set, the single source rendered here. |
+| **CRM** | **Deals** — feeds the brief and the priorities, but is *not* the task list. Deals don't become tasks automatically. |
+| **Priorities file** ([`ops/priorities.md`](../../ops/priorities.md)) | The derived **"Top 3" output** a ritual writes — a *render target*, never a source you query back as if it were the full list. |
+
+The trap is treating the priorities file as a second source: a routine reads its own
+Top-3 output, re-ranks it, and now it disagrees with the task tool. The priorities
+file only ever *receives* the derived view; the task tool is the source.
+
+## See also
+
+- [`crm-usage.md`](crm-usage.md) — the deal lane, and why tasks and deals stay apart.
+- [`../scheduling/cloud-routines.md`](../scheduling/cloud-routines.md) — the routines
+  that must defer to this spec rather than each rendering the list their own way.

--- a/.claude/scheduling/README.md
+++ b/.claude/scheduling/README.md
@@ -1,0 +1,31 @@
+# Scheduling — run the rituals on their own
+
+The rituals in [`.claude/commands/`](../commands/) are worth running on a clock,
+not just when you remember. There are three places a schedule can live, and they
+do different jobs — pick by what the job needs.
+
+| Layer | Runs where | Runs what | Machine awake? | Set up in |
+|---|---|---|---|---|
+| **OS scheduler** (cron / launchd) | your machine | full rituals (model + your tools) | ✅ required | your crontab — `claude -p "/morning-briefing"` |
+| **Cloud Routines** | Anthropic cloud | full rituals (model + your tools) | ❌ no | [`cloud-routines.md`](cloud-routines.md) |
+| **CI backstop** (GitHub Actions) | GitHub cloud | deterministic, no-model checks only | ❌ no | [`scheduled-reviews.yml`](../../.github/workflows/scheduled-reviews.yml) |
+
+Both the OS scheduler and Cloud Routines are valid triggers for the **full**
+rituals — the only difference is whether your laptop has to be awake. Start with
+whichever fits; many people run cron locally and a cloud routine as the backstop
+for when the lid is closed.
+
+The **CI backstop** is a different layer: GitHub Actions can't reach your OAuth
+integrations (it's headless — see the note in [`cloud-routines.md`](cloud-routines.md)),
+so it never runs a real ritual. It runs the **deterministic checks** in
+[`../scripts/checks/growth-os-checks.sh`](../scripts/checks/growth-os-checks.sh) —
+structure, freshness, broken local links — so a problem with the operating files
+surfaces even in a week when nothing else ran. A failing scheduled run emails the
+repo owner; that email *is* the signal.
+
+## Start here
+
+- **Run it in the cloud:** [`cloud-routines.md`](cloud-routines.md) — the full
+  runbook (connectors, web-UI + `/schedule` CLI, the paste-ready prompt template).
+- **Add the backstop:** [`scheduled-reviews.yml`](../../.github/workflows/scheduled-reviews.yml)
+  runs the checks on a weekly cron from the default branch.

--- a/.claude/scheduling/cloud-routines.md
+++ b/.claude/scheduling/cloud-routines.md
@@ -1,0 +1,149 @@
+# Cloud Routines — run your daily rituals without a local machine
+
+> Run the rituals in [`.claude/commands/`](../commands/) on a schedule, even when
+> your laptop is closed. Replace every `<placeholder>` with your own repo,
+> timezone, and integrations.
+
+Most "AI chief of staff" setups schedule their daily rituals with a local
+scheduler (cron / launchd) that shells out to `claude -p "/morning-briefing"`.
+That works, but it only fires **when your machine is awake** — close the lid and
+the briefing silently doesn't run.
+
+**Routines** (Claude Code on the web) fix that: they run a scheduled session on
+Anthropic-managed infrastructure that executes a slash command such as
+`/morning-briefing`, independent of any machine of yours.
+
+## The three scheduling layers
+
+| Layer | Runs where | Runs what | Machine awake? |
+|---|---|---|---|
+| OS scheduler (cron / launchd) | your machine | full rituals (model + your tools) | ✅ required |
+| **Cloud Routines** (this guide) | Anthropic cloud | full rituals (model + your tools) | ❌ no |
+| CI backstop (GitHub Actions) | GitHub cloud | deterministic, no-model checks only | ❌ no |
+
+Use **Routines** for anything that needs the model + your integrations; use a
+GitHub Actions `schedule:` job only for deterministic checks — that's the CI
+backstop, wired up in [`scripts/checks/`](../scripts/checks/) and
+[`.github/workflows/scheduled-reviews.yml`](../../.github/workflows/scheduled-reviews.yml)
+(see the last section for why Actions can't run the full ritual). The same table,
+from the reliability angle, is in [`README.md`](README.md).
+
+## Prerequisite — your integrations must be account-level connectors
+
+This is the make-or-break detail. A routine can only use integrations connected to
+your **claude.ai account** as **connectors** (<https://claude.ai/customize/connectors>),
+**not** MCP servers you added locally with `claude mcp add` or in a gitignored
+`.mcp.json`.
+
+- If a routine needs your task tool / calendar / meeting-notes tool / CRM / chat
+  (e.g. Notion, Google Calendar, Slack), each must appear in the routine's
+  **Connectors** tab.
+- Local-only MCP servers won't appear unless you add them as a connector **or**
+  declare them in a committed `.mcp.json` (which travels with the cloned repo).
+  This kit keeps `.mcp.json` gitignored by default — see
+  [Connect your tools](../../README.md#make-it-yours) — so for routines, prefer
+  account connectors.
+- Connector traffic routes through Anthropic, so connectors work **without** adding
+  their domains to the environment's **Allowed domains** list.
+
+**Always do a `Run now` first** — a routine whose connectors aren't authorized still
+runs, but produces an empty result. Verify before you trust the schedule.
+
+## What to schedule
+
+The rituals this chassis ships, on a weekday loop:
+
+| Routine | Schedule | Cron (routine's local tz) |
+|---|---|---|
+| [`/morning-briefing`](../commands/morning-briefing.md) | Weekdays, morning | `30 7 * * 1-5` |
+| [`/midday-checkin`](../commands/midday-checkin.md) | Weekdays, midday | `0 14 * * 1-5` |
+| [`/end-of-day`](../commands/end-of-day.md) | Weekdays, late afternoon | `30 17 * * 1-5` |
+| [`/weekly-review`](../commands/weekly-review.md) | Friday, late afternoon | `0 16 * * 5` |
+
+> Cron in a routine is evaluated in the **routine's own timezone**, not UTC — set
+> the timezone to `<your timezone, e.g. Europe/London>` and use clock times directly.
+
+## Create a routine (web UI)
+
+1. Go to **<https://claude.ai/code/routines>** → **New routine**.
+2. **Name** it (e.g. `morning-briefing`).
+3. **Prompt** — paste the matching prompt from *Routine prompts* below.
+4. **Repository:** `<your-org>/<your-repo>` (your fork of this chassis), branch `main`.
+5. **Environment:** the cloud environment configured for that repo (so connectors +
+   env vars match an interactive session).
+6. **Connectors tab:** confirm every integration your routine needs is present.
+7. **Trigger:** Schedule → Daily → the days/time you want → your timezone.
+8. **Create**, then **Run now** to verify connectors fire (and any email sends).
+9. Repeat per routine.
+
+## Create from the CLI
+
+From a **local** Claude Code CLI (the `/schedule` command talks to the same backend):
+
+```
+/schedule run /morning-briefing every weekday at 07:30 <your timezone>
+```
+
+`/schedule list` / `/schedule update` manage existing routines.
+
+> Note: a **headless web execution environment does not expose the routine-creation
+> tool** — create routines from the web UI or a local CLI, not from inside an
+> automated web session.
+
+## Routine prompts (paste-ready, template)
+
+Keep each routine prompt thin: invoke the committed slash command (whose definition
+travels with the cloned repo and is your single source of truth) and add only the
+cross-cutting run constraints.
+
+```
+Run <your routine>. In repo <your-org>/<your-repo> (branch main, cloned in your
+workspace), execute the slash command /<routine-name> (defined in
+.claude/commands/<routine-name>.md) end to end, honoring CLAUDE.md and the rules
+in .claude/rules/. Use the connected integrations it needs (e.g. task tool,
+calendar, meeting-notes tool, CRM, chat); if one is unavailable, degrade
+gracefully, note it, and continue — never abort. Write all updates the command
+specifies. If an email/delivery key is configured, send the output. Run
+autonomously; do not wait for confirmation.
+```
+
+Because the routine runs **autonomously**, the rules it honors do real work here —
+in particular [`.claude/rules/crm-usage.md`](../rules/crm-usage.md) (read-before-write,
+append-don't-overwrite, log every write) governs what an unattended run is allowed
+to change, and [`.claude/rules/todo-single-source.md`](../rules/todo-single-source.md)
+keeps a routine from re-rendering the to-do list a different way than your
+interactive session does.
+
+## Email / external delivery
+
+If your routine delivers output via an external API (e.g. Resend for email), that
+API is **not** a connector: set its key (e.g. `RESEND_API_KEY`) in the routine's
+**environment** variables and add its domain (e.g. `api.resend.com`) to that
+environment's **Allowed domains**. (Connectors skip the allowlist; plain APIs don't.)
+
+## Limits & notes
+
+- **Minimum interval** is 1 hour; routines count against your daily routine-run
+  limit (see <https://claude.ai/code/routines>).
+- Routines run **autonomously** — no permission prompts mid-run. Make prompts
+  explicit about "degrade gracefully, never abort."
+- **Why GitHub Actions can't run the full ritual:** OAuth-based MCP integrations
+  (task tools, calendars, most meeting-notes tools) require interactive,
+  browser-based authorization, which a headless Actions runner can't do. So an
+  Actions `schedule:` job can drive `claude -p` with an `ANTHROPIC_API_KEY`, but it
+  can't reach your OAuth integrations — use it only for **static-token** integrations
+  or **deterministic, no-model checks** (the CI backstop). For anything needing your
+  connectors, use Routines.
+
+## See also
+
+- [`README.md`](README.md) — the scheduling overview and the three-layer table.
+- [`.claude/rules/`](../rules/) — the rules a routine honors when it runs unattended.
+- [`../../docs/connecting-a-crm.md`](../../docs/connecting-a-crm.md) — projecting a
+  CRM into `ops/pipeline.md`, which the morning routine reads.
+
+## Sources
+
+- Routines: <https://code.claude.com/docs/en/routines>
+- Claude Code on the web (environments, connectors, network): <https://code.claude.com/docs/en/claude-code-on-the-web>
+- GitHub Actions: <https://code.claude.com/docs/en/github-actions>

--- a/.claude/scripts/checks/growth-os-checks.sh
+++ b/.claude/scripts/checks/growth-os-checks.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# growth-os-checks.sh — deterministic, no-model health checks for the operating
+# files. Runs anywhere: pure bash + coreutils, no API key, no MCP, no Claude.
+#
+# This is the CI backstop layer (see .claude/scheduling/README.md): the full
+# rituals need the model and your integrations, but these checks don't — so they
+# can run on a GitHub Actions schedule from the default branch and catch a
+# structural problem even in a week when nothing else ran.
+#
+# Contract:
+#   HARD failure  -> counts toward a non-zero exit (CI fails, owner gets emailed).
+#   SOFT warning  -> printed, but never changes the exit code (advisory only).
+# Exit 1 if any HARD failure, else exit 0.
+
+# Advisory freshness threshold, in days. Meaningful mainly in a populated fork;
+# the shipped fictional ops/ data will eventually trip it (harmless — it's SOFT).
+FRESH_DAYS=14
+
+# --- locate the repo root, however we were invoked ---------------------------
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if REPO=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null); then
+  :
+else
+  REPO=$(cd "$SCRIPT_DIR/../../.." && pwd)
+fi
+cd "$REPO" || { echo "cannot cd to repo root: $REPO" >&2; exit 1; }
+
+HARD=0
+SOFT=0
+hard() { HARD=$((HARD + 1)); printf '  HARD  %s\n' "$1"; }
+soft() { SOFT=$((SOFT + 1)); printf '  SOFT  %s\n' "$1"; }
+pass() { printf '  ok    %s\n' "$1"; }
+
+today_epoch=$(date +%s)
+
+# days_since "YYYY-MM-DD" -> integer days, or empty if the date can't be parsed
+# (GNU date and BSD/macOS date take different flags; try both, then give up).
+days_since() {
+  local d=$1 e=""
+  if e=$(date -d "$d" +%s 2>/dev/null); then
+    :
+  elif e=$(date -j -f "%Y-%m-%d" "$d" +%s 2>/dev/null); then
+    :
+  else
+    echo ""
+    return 0
+  fi
+  echo $(( (today_epoch - e) / 86400 ))
+}
+
+# newest_date_in FILE -> most recent YYYY-MM-DD used as a "## "/"### " heading
+newest_date_in() {
+  grep -hoE '^#{2,}[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}' "$1" 2>/dev/null \
+    | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort -r | head -n1
+}
+
+# --- 1. Structure: the files the rituals depend on ---------------------------
+echo "Structure"
+required=(
+  CLAUDE.md
+  README.md
+  .claude/settings.json
+  .claude/commands/morning-briefing.md
+  .claude/commands/midday-checkin.md
+  .claude/commands/end-of-day.md
+  .claude/commands/weekly-review.md
+  ops/priorities.md
+  ops/daily-log.md
+  ops/pipeline.md
+  ops/customers.md
+  ops/roadmap-signals.md
+  ops/feedback-log.md
+)
+for rel in "${required[@]}"; do
+  if [ -e "$rel" ]; then
+    pass "present: $rel"
+  else
+    hard "missing required file: $rel"
+  fi
+done
+
+# --- 2. Broken local links across all tracked markdown -----------------------
+echo "Local links"
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  md_files=$(git ls-files '*.md')
+else
+  md_files=$(find . -name '*.md' -not -path './.git/*')
+fi
+link_problems=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  dir=$(dirname "$f")
+  # awk skips fenced code blocks (```), then prints every ](target) target.
+  while IFS= read -r raw; do
+    tgt=${raw%% *}   # drop any "title" after the path
+    tgt=${tgt%%#*}   # drop any #anchor
+    [ -z "$tgt" ] && continue
+    case "$tgt" in
+      http://*|https://*|mailto:*|tel:*|//*) continue ;;
+    esac
+    if [ ! -e "$dir/$tgt" ]; then
+      hard "broken link in $f -> $raw"
+      link_problems=$((link_problems + 1))
+    fi
+  done < <(awk '
+    /^```/ { infence = !infence; next }
+    infence { next }
+    {
+      line = $0
+      while (match(line, /\]\([^)]+\)/)) {
+        print substr(line, RSTART + 2, RLENGTH - 3)
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+  ' "$f")
+done <<EOF
+$md_files
+EOF
+[ "$link_problems" -eq 0 ] && pass "all relative markdown links resolve"
+
+# --- 3. Freshness: has the day been logged lately? (advisory) ----------------
+echo "Freshness"
+if [ -f ops/daily-log.md ]; then
+  nd=$(newest_date_in ops/daily-log.md)
+  if [ -n "$nd" ]; then
+    ds=$(days_since "$nd")
+    if [ -n "$ds" ] && [ "$ds" -gt "$FRESH_DAYS" ]; then
+      soft "ops/daily-log.md newest entry is $nd (${ds}d old) — the log has gone quiet"
+    else
+      pass "ops/daily-log.md current (newest ${nd:-unknown})"
+    fi
+  else
+    soft "ops/daily-log.md has no dated entries yet"
+  fi
+fi
+
+# --- 4. Staleness: is the cross-function loop still moving? (advisory) --------
+echo "Loop"
+if [ -f ops/feedback-log.md ]; then
+  fd=$(newest_date_in ops/feedback-log.md)
+  if [ -n "$fd" ]; then
+    fs=$(days_since "$fd")
+    if [ -n "$fs" ] && [ "$fs" -gt "$FRESH_DAYS" ]; then
+      soft "ops/feedback-log.md newest signal is $fd (${fs}d old) — the sales<->product loop has gone quiet"
+    else
+      pass "ops/feedback-log.md current (newest ${fd:-unknown})"
+    fi
+  else
+    soft "ops/feedback-log.md has no dated signals yet"
+  fi
+fi
+
+# --- summary -----------------------------------------------------------------
+echo
+echo "Summary: ${HARD} hard, ${SOFT} soft."
+if [ "$HARD" -gt 0 ]; then
+  echo "FAIL — $HARD hard check(s) failed."
+  exit 1
+fi
+echo "PASS — no hard failures."
+exit 0

--- a/.claude/skills/marketing-feedback/SKILL.md
+++ b/.claude/skills/marketing-feedback/SKILL.md
@@ -5,7 +5,7 @@ description: Turn what sales hears in the field into marketing actions. Trigger 
 
 # Marketing Feedback
 
-The loop that keeps sales and marketing as one system: field intelligence flows from sales back to marketing on a cadence, instead of dying inside a meeting note. This is mechanism #5 from [`docs/why-align.md`](../../docs/why-align.md) — made concrete as a tagged line in a shared log.
+The loop that keeps sales and marketing as one system: field intelligence flows from sales back to marketing on a cadence, instead of dying inside a meeting note. This is mechanism #5 from [`docs/why-align.md`](../../../docs/why-align.md) — made concrete as a tagged line in a shared log.
 
 From a source — a note in `ops/daily-log.md`, a file in `demo/meetings/`, a call recap, a deal update:
 

--- a/.claude/skills/onboarding-handoff/SKILL.md
+++ b/.claude/skills/onboarding-handoff/SKILL.md
@@ -5,7 +5,7 @@ description: Run the Won→onboarding handoff — the seam most teams drop. Trig
 
 # Onboarding Handoff (Won → onboarding)
 
-The handoff most teams never define: a signed deal drops silently into a customer-success void, the value the buyer was sold gets lost, and the renewal clock starts late. This is handoff **H3** in [`docs/operating-model.md`](../../docs/operating-model.md) — made concrete as a 48-hour checklist that turns a won deal into the first row of the account book.
+The handoff most teams never define: a signed deal drops silently into a customer-success void, the value the buyer was sold gets lost, and the renewal clock starts late. This is handoff **H3** in [`docs/operating-model.md`](../../../docs/operating-model.md) — made concrete as a 48-hour checklist that turns a won deal into the first row of the account book.
 
 From the won deal (point me at the row in `ops/pipeline.md`, or paste the deal context):
 

--- a/.claude/skills/product-signal/SKILL.md
+++ b/.claude/skills/product-signal/SKILL.md
@@ -5,7 +5,7 @@ description: Route post-sale and field signals into product's roadmap queue, and
 
 # Product Signal
 
-The product function's place in the loop. Marketing has `marketing-feedback`; CS has `account-health`; this is product's. It pulls the signals that should shape what gets built out of the shared log into product's own triage queue, and — for anything shipped — writes the one-line "what this means for the buyer" so a feature doesn't land silently. This closes handoffs **H4** (CS→product) and **H5** (product→GTM) in [`docs/operating-model.md`](../../docs/operating-model.md).
+The product function's place in the loop. Marketing has `marketing-feedback`; CS has `account-health`; this is product's. It pulls the signals that should shape what gets built out of the shared log into product's own triage queue, and — for anything shipped — writes the one-line "what this means for the buyer" so a feature doesn't land silently. This closes handoffs **H4** (CS→product) and **H5** (product→GTM) in [`docs/operating-model.md`](../../../docs/operating-model.md).
 
 From the shared feedback log (`demo/feedback-log.md`, or your own) and `ops/customers.md`:
 

--- a/.claude/skills/retention-feedback/SKILL.md
+++ b/.claude/skills/retention-feedback/SKILL.md
@@ -5,7 +5,7 @@ description: Turn what customer success hears after the sale into product and re
 
 # Retention Feedback
 
-The loop that keeps the *post-sale* half of the motion connected to product — the half the funnel forgets. Sales→marketing is the loop everyone can see; this is its mirror on the right side of the bowtie. Field intelligence from onboarding, adoption, and renewal flows back to product and CS on a cadence, instead of dying in a QBR. This is the four-function version of the alignment thesis in [`docs/why-align.md`](../../docs/why-align.md) — made concrete as a tagged line in the same shared log the `marketing-feedback` skill writes to.
+The loop that keeps the *post-sale* half of the motion connected to product — the half the funnel forgets. Sales→marketing is the loop everyone can see; this is its mirror on the right side of the bowtie. Field intelligence from onboarding, adoption, and renewal flows back to product and CS on a cadence, instead of dying in a QBR. This is the four-function version of the alignment thesis in [`docs/why-align.md`](../../../docs/why-align.md) — made concrete as a tagged line in the same shared log the `marketing-feedback` skill writes to.
 
 From a source — an onboarding note, a usage review, a support thread, a renewal call, a deal update:
 

--- a/.github/workflows/scheduled-reviews.yml
+++ b/.github/workflows/scheduled-reviews.yml
@@ -1,0 +1,34 @@
+name: scheduled-reviews
+
+# The CI backstop layer (see .claude/scheduling/README.md). The full rituals need
+# the model and your OAuth integrations, which a headless Actions runner can't
+# reach — so this never runs a real ritual. It runs the deterministic, no-model
+# checks in .claude/scripts/checks/growth-os-checks.sh (structure, broken local
+# links, freshness) so a structural problem surfaces even in a quiet week.
+#
+# Note: a `schedule:` trigger only fires from the DEFAULT branch. A failing
+# scheduled run emails the repo owner — that email is the signal. The PR and
+# manual triggers below let you exercise the checks without waiting for the cron.
+on:
+  schedule:
+    - cron: "0 8 * * 1"   # Mondays 08:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "ops/**"
+      - "docs/**"
+      - ".claude/**"
+      - "**/*.md"
+      - ".claude/scripts/checks/growth-os-checks.sh"
+      - ".github/workflows/scheduled-reviews.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run deterministic operating-file checks
+        run: bash .claude/scripts/checks/growth-os-checks.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,15 +1,18 @@
 name: shellcheck
 
-# The hooks in .claude/hooks/ are the repo's guardrails. Lint them on every
-# change so a shell mistake can't slip in. Scoped to the hook scripts only.
+# The bash in .claude/hooks/ (guardrails) and .claude/scripts/ (the CI-backstop
+# checks) is repo infrastructure. Lint it on every change so a shell mistake
+# can't slip in.
 on:
   push:
     paths:
       - ".claude/hooks/**"
+      - ".claude/scripts/**"
       - ".github/workflows/shellcheck.yml"
   pull_request:
     paths:
       - ".claude/hooks/**"
+      - ".claude/scripts/**"
       - ".github/workflows/shellcheck.yml"
 
 permissions:
@@ -20,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Lint .claude/hooks/*.sh
+      - name: Lint hook and script bash
         run: |
           shellcheck --version
-          shellcheck .claude/hooks/*.sh
+          find .claude/hooks .claude/scripts -name '*.sh' -print -exec shellcheck {} +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cloud Routines scheduling** (`.claude/scheduling/`) — a runbook for running the
   rituals on Anthropic-managed infrastructure without your machine awake
   (`cloud-routines.md`), plus a three-layer scheduling overview (OS scheduler vs
-  cloud Routines vs CI backstop) in `.claude/scheduling/README.md`. (#PR)
+  cloud Routines vs CI backstop) in `.claude/scheduling/README.md`. (#31)
 - **Operating rules** (`.claude/rules/`) — standing constraints every session *and*
   autonomous routine honors: `crm-usage.md` (the docs-first MCP access protocol, the
   three-lane tasks≠deals convention, and write-authority guardrails for unattended
   runs) and `todo-single-source.md` (one canonical to-do render spec every entry path
-  defers to). Wired into the rituals and `CLAUDE.md`. (#PR)
+  defers to). Wired into the rituals and `CLAUDE.md`. (#31)
 - **Scheduled-reviews CI backstop** (`.github/workflows/scheduled-reviews.yml` +
   `.claude/scripts/checks/growth-os-checks.sh`) — deterministic, no-model checks
   (structure, freshness, broken local links; HARD→exit 1, SOFT→exit 0) run weekly
   from the default branch, so a structural problem surfaces even in a quiet week.
-  `shellcheck` CI now lints `.claude/scripts/` alongside `.claude/hooks/`. (#PR)
+  `shellcheck` CI now lints `.claude/scripts/` alongside `.claude/hooks/`. (#31)
 - **Loop signals at session start** (`.claude/hooks/session-start.sh`) — the hook now
   also surfaces the freshest `ops/feedback-log.md` signals, so the cross-function
-  loop can't go stale silently. (#PR)
+  loop can't go stale silently. (#31)
 - **Principles from science** (`docs/principles-from-science.md`) — twenty-one
   portable operating principles drawn from seven sciences, each with two sourced
   quotes and a worked go-to-market example; linked from the README docs table. (#26)
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken doc links in four skill templates** (`marketing-feedback`,
   `onboarding-handoff`, `product-signal`, `retention-feedback`) — they pointed at
   `../../docs/…` (which resolves to a non-existent `.claude/docs/`) instead of
-  `../../../docs/…`. Surfaced by the new checks script on its first run. (#PR)
+  `../../../docs/…`. Surfaced by the new checks script on its first run. (#31)
 
 ## [0.1.0] — 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cloud Routines scheduling** (`.claude/scheduling/`) — a runbook for running the
+  rituals on Anthropic-managed infrastructure without your machine awake
+  (`cloud-routines.md`), plus a three-layer scheduling overview (OS scheduler vs
+  cloud Routines vs CI backstop) in `.claude/scheduling/README.md`. (#PR)
+- **Operating rules** (`.claude/rules/`) — standing constraints every session *and*
+  autonomous routine honors: `crm-usage.md` (the docs-first MCP access protocol, the
+  three-lane tasks≠deals convention, and write-authority guardrails for unattended
+  runs) and `todo-single-source.md` (one canonical to-do render spec every entry path
+  defers to). Wired into the rituals and `CLAUDE.md`. (#PR)
+- **Scheduled-reviews CI backstop** (`.github/workflows/scheduled-reviews.yml` +
+  `.claude/scripts/checks/growth-os-checks.sh`) — deterministic, no-model checks
+  (structure, freshness, broken local links; HARD→exit 1, SOFT→exit 0) run weekly
+  from the default branch, so a structural problem surfaces even in a quiet week.
+  `shellcheck` CI now lints `.claude/scripts/` alongside `.claude/hooks/`. (#PR)
+- **Loop signals at session start** (`.claude/hooks/session-start.sh`) — the hook now
+  also surfaces the freshest `ops/feedback-log.md` signals, so the cross-function
+  loop can't go stale silently. (#PR)
 - **Principles from science** (`docs/principles-from-science.md`) — twenty-one
   portable operating principles drawn from seven sciences, each with two sourced
   quotes and a worked go-to-market example; linked from the README docs table. (#26)
@@ -46,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Commit secret-guard** (`.claude/hooks/pre-commit-guard.sh`) — broadened to
   catch GitHub fine-grained PATs and OAuth/server tokens, Google API keys, and
   Stripe live keys, with the covered formats documented inline. (#8)
+
+### Fixed
+
+- **Broken doc links in four skill templates** (`marketing-feedback`,
+  `onboarding-handoff`, `product-signal`, `retention-feedback`) — they pointed at
+  `../../docs/…` (which resolves to a non-existent `.claude/docs/`) instead of
+  `../../../docs/…`. Surfaced by the new checks script on its first run. (#PR)
 
 ## [0.1.0] — 2026-05-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,24 @@ This project uses Claude Code as a go-to-market operating environment — market
 
 Guardrails run on events, not memory (`.claude/hooks/`):
 
-- **SessionStart** surfaces `ops/priorities.md`. On remote / Claude-Code-on-the-web sessions only, a bootstrap step (`web-bootstrap.sh`) also installs the hook linter (`shellcheck`) so you can lint the hooks in-session, matching CI; it's skipped locally and never blocks.
+- **SessionStart** surfaces `ops/priorities.md` and the freshest `ops/feedback-log.md` signals (so the cross-function loop can't go stale silently). On remote / Claude-Code-on-the-web sessions only, a bootstrap step (`web-bootstrap.sh`) also installs the hook linter (`shellcheck`) so you can lint the hooks in-session, matching CI; it's skipped locally and never blocks.
 - **PreCompact** re-injects priorities + the latest log entry so long sessions don't lose the thread.
 - **PreToolUse(Edit|Write)** blocks writes to secrets, keys, and `.env`.
 - **Stop** nudges you to `/end-of-day` until today is logged.
 - A **git pre-commit guard** (`pre-commit-guard.sh`, install once) blocks commits containing likely secrets.
 
 All pure bash (one uses `python3` to read a payload). No API keys, no MCP required. The full thinking is in `docs/methodology.md`.
+
+## Rules
+
+Standing constraints every session honors — interactive or an autonomous [cloud routine](.claude/scheduling/cloud-routines.md) — live in `.claude/rules/` (see [`.claude/rules/README.md`](.claude/rules/README.md)):
+
+- **CRM over MCP** ([`crm-usage.md`](.claude/rules/crm-usage.md)) — the three-lane convention (tasks ≠ deals), the docs-first access protocol, and the write-authority guardrails an unattended run must respect.
+- **One to-do list** ([`todo-single-source.md`](.claude/rules/todo-single-source.md)) — the canonical way the to-do list is queried and rendered, so every entry path shows the same list. Pull the whole open set; derive urgency at render; never re-group it per ritual.
+
+## Scheduling
+
+Run the rituals on a clock — locally (cron/launchd), in the cloud, or as a CI backstop. The three layers and setup are in [`.claude/scheduling/`](.claude/scheduling/README.md): cloud Routines run the full rituals without your machine awake; a GitHub Actions `schedule:` runs only the deterministic checks in `.claude/scripts/checks/`.
 
 ## Extending with tools
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Nothing there is real — delete `demo/` whenever you like.
 | `.claude/hooks/` | Five guardrails: session-start context, **state re-injection across compaction**, a **commit secret-guard**, sensitive-file protection, an end-of-day nudge — plus a **web-session bootstrap** that installs the hook linter (`shellcheck`) on remote / Claude-Code-on-the-web containers |
 | `.claude/commands/` | Daily rituals you invoke by name: `/morning-briefing`, `/midday-checkin`, `/end-of-day`, `/weekly-review`, plus `/demo-briefing` |
 | `.claude/skills/` | Skill templates grouped by the four growth functions (see below) — so the balance across marketing, sales, product, and retention is visible, not acquisition-only |
+| `.claude/rules/` | Standing constraints every session honors — how to reach a CRM over MCP (`crm-usage.md`) and how the to-do list renders one canonical way (`todo-single-source.md`); obeyed by interactive rituals and autonomous routines alike |
+| `.claude/scheduling/` | Run the rituals on a clock — locally (cron/launchd), as **cloud Routines** (no machine awake), or as a CI backstop (the deterministic checks in `.claude/scripts/checks/`, run by a GitHub Actions `schedule:`). Full runbook in `cloud-routines.md` |
 | `ops/` | Your plain-text playbooks — `priorities.md`, `daily-log.md`, `pipeline.md` (left side), `customers.md` and `roadmap-signals.md` (right side), and `feedback-log.md` (the shared cross-function loop). Start here. |
 | `demo/` | A fictional pipeline *and* customer book so you can see the whole motion work (and present from it safely) |
 | `docs/operating-model.md` | The spine: the bowtie, the four functions, the six handoffs (H1–H6), the one number (net revenue retention), and the three shared definitions |
@@ -101,7 +103,7 @@ The left side lives in `ops/pipeline.md`; the right side in `ops/customers.md` (
 - **`pre-compact.sh`** re-injects your priorities and latest log when a long session compacts — your state lives in files, so the context window can't lose the thread.
 - **`pre-commit-guard.sh`** blocks a commit if staged changes look like they contain a secret (API keys, private keys, tokens).
 - **`protect-files.sh`** stops the agent writing to `.env`, keys, and credentials.
-- **`session-start.sh`** and **`stop-reminder.sh`** open and close the day.
+- **`session-start.sh`** opens the day with your priorities *and* the freshest cross-function loop signals (so the feedback log can't go stale silently); **`stop-reminder.sh`** closes it.
 - **`web-bootstrap.sh`** runs only in remote / Claude-Code-on-the-web sessions (`CLAUDE_CODE_REMOTE=true`) and installs the one tool a fresh web container lacks — `shellcheck` — so you can lint the hooks in-session, matching CI. Skipped on your own machine, idempotent, and never blocks: a setup failure just logs a warning.
 
 All pure bash (one uses `python3` to read a payload). No API keys, no MCP — it runs anywhere out of the box.

--- a/docs/connecting-a-crm.md
+++ b/docs/connecting-a-crm.md
@@ -76,5 +76,6 @@ A full-pipeline list call can be large. Page deliberately (most list APIs cap pa
 
 ## See also
 
+- [`../.claude/rules/crm-usage.md`](../.claude/rules/crm-usage.md) — the companion *rule*: the docs-first MCP access protocol and the write-authority guardrails for reaching the CRM safely, especially under autonomous [cloud routines](../.claude/scheduling/cloud-routines.md).
 - [`operating-model.md`](operating-model.md) — the spine: where `ops/pipeline.md` sits in the four-function motion (handoff H1).
 - [`../ops/pipeline.md`](../ops/pipeline.md) — the board this projects into.


### PR DESCRIPTION
## What this changes

Ports four go-to-market patterns from a private Growth OS into this public chassis, **generically** (placeholders, no private specifics), so anyone can run the same setup. One PR, four deliverables, plus the light wiring that makes them discoverable. The patterns are one coherent theme: **machine-independent scheduling**, the **rules an autonomous routine must honor**, and the **CI backstop** that catches drift when nothing else ran.

## The four deliverables

**1. Cloud Routines scheduling doc** — `.claude/scheduling/cloud-routines.md` (+ a `README.md` with the three-layer model). Run the rituals on Anthropic-managed infrastructure with your machine closed. Covers the account-level **connector** prerequisite (connectors, *not* local `claude mcp add`), web-UI + `/schedule` CLI creation, a paste-ready prompt template, the email-delivery caveat, and why GitHub Actions can't run the full ritual (OAuth MCP can't auth headless).

**2. CRM-via-MCP rule** — `.claude/rules/crm-usage.md`. The three-lane convention (task tool = tasks, CRM = deals — don't merge them), the **docs-first access protocol** (discover → fetch schema → read/write only via discovered paths → resolve a self-scoped identity), and the **write-authority guardrails** that matter precisely because cloud routines run autonomously (read-before-write, append-don't-overwrite, log every write as an audit trail, touch only owned fields, never cascade, treat AI-generated fields as read-only) — plus a read-only / safe-writes / full read-write authority choice. Complements (doesn't duplicate) the existing `docs/connecting-a-crm.md`, which owns the projection mechanics; the two now cross-link.

**3. Single-source-of-truth to-do rendering** — `.claude/rules/todo-single-source.md`. One canonical render spec; every entry path (session start, each ritual, **each cloud routine**) defers to it. Don't pre-filter at query time — pull the whole open set, derive urgency at render. Routines compose around the one list; they never re-render or fork it. Three lanes: task tool = the list, CRM = deals, priorities file = the derived "Top 3" *output* (not a source).

**4. Scheduled-reviews reliability layer** — `.claude/scripts/checks/growth-os-checks.sh` + `.github/workflows/scheduled-reviews.yml`. Deterministic, no-model checks (structure / freshness / broken local links) with a **HARD → exit 1, SOFT → exit 0** contract, run weekly from the default branch (a failing run emails the repo owner = the signal). Plus a SessionStart hook that now surfaces the freshest `ops/feedback-log.md` signals so the loop can't go stale silently. `shellcheck` CI now also lints `.claude/scripts/`.

## Wiring & a fix

- Rules wired into the rituals — `morning-briefing` (read the CRM/pipeline for stalls, closing-soon, qualification flags), `midday-checkin` / `end-of-day` (persist + reconcile the mirror), `weekly-review` (reconcile) — and into `CLAUDE.md`; new dirs surfaced in the README catalog and `CHANGELOG.md`.
- The new checks script caught **four pre-existing broken doc links** in skill templates (`../../docs/…`, which resolves to a non-existent `.claude/docs/`, → `../../../docs/…`) — fixed. The reliability layer earned its place on its first run.

## Verification

- `shellcheck` clean across all 6 hooks + the new checks script (CI mirror).
- `growth-os-checks.sh` passes locally: **0 hard, 0 soft** — every relative markdown link in the repo resolves.
- Both workflow YAML files parse.

## Provenance (private repo — pointers for context, not fetchable from here)

- Cloud routines + scheduling: `langoptima-growth-os` PR #159, commit `a62a0fc`.
- CRM rule + routine wiring: PR #159, commit `7ef6a11`.
- To-do unification: PR #159, commit `bcd878d`.
- Reliability layer: PR #155 (merged).

Public sources cited in the cloud-routines doc: `code.claude.com/docs/en/routines`, `.../claude-code-on-the-web`, `.../github-actions`.

## Notes

- **Branch:** developed on `claude/awesome-hypatia-u4HKr` (this session's designated branch), not the handoff's suggested `feature/cloud-routines-and-crm`.
- **Generic throughout** — `<placeholders>`, no real company / integration / timezone / email.
- `CHANGELOG.md` entries reference `(#PR)` as a placeholder; I'll swap in this PR's number once assigned.

## Checklist

- [x] Plain markdown + bash only — no secrets, no real client data
- [x] `demo/` data untouched and fictional
- [x] New rules/docs are generic (`<placeholders>`)
- [x] New rules in `.claude/rules/`, scheduling in `.claude/scheduling/`, checks in `.claude/scripts/checks/`; each cross-linked
- [x] Ran the deterministic checks and `shellcheck`; both green

https://claude.ai/code/session_017a4LLRW7eZB5KxRCingGYD

---
_Generated by [Claude Code](https://claude.ai/code/session_017a4LLRW7eZB5KxRCingGYD)_