### PR TITLE
feat: Opus 4.8 settings — xhigh effort, agent memory, security plugin, prompt caching

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
+  "autoMemoryEnabled": true,
+  "plugins": ["security-guidance"],
+  "env": {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "ENABLE_PROMPT_CACHING_1H": "1"
+  },
   "permissions": {
     "allow": [
       "Read",


### PR DESCRIPTION
## Changes\n\nUpdates `.claude/settings.json` to adopt all actionable Opus 4.8 improvements from the [2026-06-01 weekly scout report](https://github.com/etrebels/LangOptima-General/pull/183).\n\n### What changed\n| Field | Before | After | Why |\n|-------|--------|-------|-----|\n| `effortLevel` | `high` | `xhigh` | Opus 4.8 defaults to `high`; must be set explicitly for agentic/coding work per CLAUDE.md |\n| `autoMemoryEnabled` | _(absent)_ | `true` | Agent memory public beta — enables persistent memory for recurring sessions |\n| `plugins` | _(absent)_ | `[\"security-guidance\"]` | Real-time vulnerability review on every code change |\n| `env` block | _(absent)_ | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` + `ENABLE_PROMPT_CACHING_1H` | Align with General repo defaults; 1h cache TTL reduces token spend on cloud runs |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UREyXshbDnJ9PfhBvo25nj)_