### PR TITLE
Make tool references brand-neutral

### DIFF
--- a/.claude/rules/crm-usage.md
+++ b/.claude/rules/crm-usage.md
@@ -18,7 +18,7 @@ routine from, say, turning a deal note into a duplicate task.
 
 | Lane | Owns | Example tool |
 |---|---|---|
-| **Task tool** | *What to do* — the to-do list | your task manager (e.g. Notion, Linear) |
+| **Task tool** | *What to do* — the to-do list | your task manager |
 | **Meeting-notes tool → wiki** | *What was said* — transcripts, summaries | your notetaker |
 | **CRM (via MCP)** | *What changed about the deal* — stage, qualification scores, opportunity fields, deal notes | your CRM |
 

--- a/.claude/scheduling/cloud-routines.md
+++ b/.claude/scheduling/cloud-routines.md
@@ -35,9 +35,8 @@ your **claude.ai account** as **connectors** (<https://claude.ai/customize/conne
 **not** MCP servers you added locally with `claude mcp add` or in a gitignored
 `.mcp.json`.
 
-- If a routine needs your task tool / calendar / meeting-notes tool / CRM / chat
-  (e.g. Notion, Google Calendar, Slack), each must appear in the routine's
-  **Connectors** tab.
+- If a routine needs your task tool / calendar / meeting-notes tool / CRM / chat,
+  each must appear in the routine's **Connectors** tab.
 - Local-only MCP servers won't appear unless you add them as a connector **or**
   declare them in a committed `.mcp.json` (which travels with the cloned repo).
   This kit keeps `.mcp.json` gitignored by default — see
@@ -116,9 +115,9 @@ interactive session does.
 
 ## Email / external delivery
 
-If your routine delivers output via an external API (e.g. Resend for email), that
-API is **not** a connector: set its key (e.g. `RESEND_API_KEY`) in the routine's
-**environment** variables and add its domain (e.g. `api.resend.com`) to that
+If your routine delivers output via an external API (e.g. an email-sending API), that
+API is **not** a connector: set its key (e.g. `EMAIL_API_KEY`) in the routine's
+**environment** variables and add its domain (e.g. `api.youremailprovider.com`) to that
 environment's **Allowed domains**. (Connectors skip the allowlist; plain APIs don't.)
 
 ## Limits & notes

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All pure bash (one uses `python3` to read a payload). No API keys, no MCP — it
 
 ## Portability
 
-The `.claude/skills/` and `.claude/commands/` are plain markdown on the Agent Skills spec, so they port to Cursor, Windsurf, and Codex with little change. The `hooks/` and `settings.json` are Claude-Code-specific — they won't carry over, and that's fine; the rituals and skills are the part worth taking elsewhere.
+The `.claude/skills/` and `.claude/commands/` are plain markdown on the Agent Skills spec, so they port to other agents that support it with little change. The `hooks/` and `settings.json` are Claude-Code-specific — they won't carry over, and that's fine; the rituals and skills are the part worth taking elsewhere.
 
 ## What's deliberately not here
 
@@ -129,13 +129,13 @@ This is **open core**. The chassis is free and MIT-licensed; the part that took 
 
 | Free — this repo (MIT) | Paid — built & run for you |
 |---|---|
-| The chassis: hooks, daily rituals, and go-to-market skill templates across all four functions, plus a 30-second runnable demo. Bring your own playbooks. | Your customized, *populated* operating system, with your best tools integrated, alongside real playbooks, positioning, pricing, ICP — plus the wider automation layer (n8n: vendor management, ICP checks, pre- and post-meeting briefings and follow-ups) as well as Blackbird.io for multilingual content processes. Built and run for you, or run by a growth operator who works this way. |
+| The chassis: hooks, daily rituals, and go-to-market skill templates across all four functions, plus a 30-second runnable demo. Bring your own playbooks. | Your customized, *populated* operating system, with your best tools integrated, alongside real playbooks, positioning, pricing, ICP — plus the wider automation layer (a workflow-automation platform: vendor management, ICP checks, pre- and post-meeting briefings and follow-ups) as well as a localization-automation platform for multilingual content processes. Built and run for you, or run by a growth operator who works this way. |
 
 The repo is the skeleton; the judgment you put inside it is the product → **[langoptima.com/features/growth](https://langoptima.com/features/growth)**.
 
 ## Who's behind this
 
-I'm Edwin Trebels — I run our company's entire go-to-market on a setup like this, and help clients run theirs. This repo is the open skeleton. The full version adds the wider automation layer (n8n handling vendor management, ICP checks, pre-meeting briefings, post-meeting debriefs and follow-ups, and the assistant that keeps the day straight; Blackbird.io for multilingual content), plus the judgment that fills the empty drawers. That part took twenty-two years and doesn't come in a folder.
+I'm Edwin Trebels — I run our company's entire go-to-market on a setup like this, and help clients run theirs. This repo is the open skeleton. The full version adds the wider automation layer (a workflow-automation platform handling vendor management, ICP checks, pre-meeting briefings, post-meeting debriefs and follow-ups, and the assistant that keeps the day straight; a localization-automation platform for multilingual content), plus the judgment that fills the empty drawers. That part took twenty-two years and doesn't come in a folder.
 
 Want it built and run for you, or a growth operator who works this way? That's what I do: [langoptima.com/features/growth](https://langoptima.com/features/growth). The thinking behind the kit is in [`docs/methodology.md`](docs/methodology.md).
 

--- a/docs/connecting-a-crm.md
+++ b/docs/connecting-a-crm.md
@@ -1,6 +1,6 @@
 # Connecting a CRM (optional)
 
-This kit works fine with [`ops/pipeline.md`](../ops/pipeline.md) as your hand-maintained board. But if you already have a CRM (HubSpot, Salesforce, Attio, …), **don't run two pipelines.** Make your CRM the source of truth and treat `ops/pipeline.md` as a *projection* of it. A hand-typed board that drifts from the CRM is worse than no board.
+This kit works fine with [`ops/pipeline.md`](../ops/pipeline.md) as your hand-maintained board. But if you already have a CRM, **don't run two pipelines.** Make your CRM the source of truth and treat `ops/pipeline.md` as a *projection* of it. A hand-typed board that drifts from the CRM is worse than no board.
 
 ## The pattern: project, don't duplicate
 


### PR DESCRIPTION
## Summary

- Replace vendor brand names with product-category equivalents so the open-source kit stays brand-neutral and bring-your-own.
- `README.md`: `n8n` → "a workflow-automation platform"; `Blackbird.io` → "a localization-automation platform"; `Cursor/Windsurf/Codex` → "other agents that support [the Agent Skills spec]".
- `crm-usage.md`, `cloud-routines.md`, `connecting-a-crm.md`: genericize the illustrative `Notion / Linear / Slack / Google Calendar / Resend / HubSpot / Salesforce / Attio` examples to their category equivalents.

## Deliberately left intact

- The secret-scanner's **credential-format names** (`Slack token`, `Stripe live key`, GitHub/Google/AWS/OpenAI) in `pre-commit-guard.sh` and `CHANGELOG.md` — these are security detection specs, not tool recommendations; renaming would make them inaccurate.
- The `HubSpot *State of Inbound* 2015` **research citation** in `docs/operating-model.md` and `docs/why-align.md` — evidence, not a tool pick.
- Platform names the kit runs on (Claude Code, GitHub).

## Test plan

- `git grep` for the target brands returns clean (excluding the citation/security contexts above).
- Diff is wording-only across 4 files (10 insertions, 11 deletions); no behavior, hooks, or schema changes.

https://claude.ai/code/session_01S4YD6FmEKitDXeMZM5Edrz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4YD6FmEKitDXeMZM5Edrz)_