### PR TITLE
Add retention act-skills, monthly retention report, and ARR to the customer book

### DIFF
--- a/.claude/commands/retention-report.md
+++ b/.claude/commands/retention-report.md
@@ -1,0 +1,26 @@
+---
+description: Monthly retention readout — NRR, GRR, churn by reason, and expansion, from the customer book in one page.
+---
+
+# Retention Report
+
+The monthly readout for the right side of the bowtie. `/weekly-review` reads the direction; this puts a number on it: are you keeping and growing the revenue you've already won, or filling a leaking bucket? It rolls the account book up to the one number the whole motion answers to — net revenue retention.
+
+From `ops/customers.md` (the account book, with its `ARR` column) and its git history over the period:
+
+1. **Set the period and the starting base.** Default to the trailing month (or quarter). The cohort is the accounts you held at the *start* of the period — reconstruct their starting ARR from the book's git history (`git show <commit-as-of-period-start>:ops/customers.md`). New logos signed mid-period don't count toward retention.
+2. **Compute GRR and NRR — from the numbers, never eyeballed.** Name the formula, then compute:
+   - **GRR** (gross revenue retention) = (starting ARR − downgrades − churn) ÷ starting ARR. Caps at 100% — it's the floor, what you keep *before* any expansion.
+   - **NRR** (net revenue retention) = (starting ARR + expansion − downgrades − churn) ÷ starting ARR. Above 100% means the base grew without a single new logo.
+   - If the book doesn't carry `ARR` yet, say so and report the **count-based** picture instead (logos retained / at-risk / churned / expanded) — and add the column so next month computes.
+3. **Churn by reason.** Group the accounts lost or downgraded this period by the *real* reason — value miss, champion exit, budget, product gap, fit. Use the same reasons `churn-save` logs. The reason column is the roadmap for retention; counts without reasons can't be acted on.
+4. **Expansion.** Which accounts grew, by how much, and off what trigger — the `EXPANSION-SIGNAL`s `expansion-play` worked. Net expansion is what carries NRR above 100%.
+5. **The one read.** State it plainly: is the base net-expanding or net-leaking? Below 100% NRR means acquisition spend is filling a leaking bucket ([`docs/operating-model.md`](../../docs/operating-model.md) — the one number). One line.
+6. **Next month's two bets.** The single biggest retention risk to clear and the single biggest expansion to chase. Write them to the top of `ops/priorities.md`.
+
+Lead with the two numbers and the one read. Don't pad it, and don't invent a number the book can't support — an honest count beats a confident guess. If a CRM is your system of record for ARR, reconcile against it per [`.claude/rules/crm-usage.md`](../rules/crm-usage.md) — read-only beyond what the daily rituals already persisted.
+
+## Depth
+- quick: NRR, GRR, and the one read.
+- standard: the full report above — both numbers, churn by reason, expansion, next month's two bets.
+- deep: + month-over-month trend on each number, the logo-vs-revenue retention split, and the cohort detail behind the move.

--- a/.claude/scheduling/cloud-routines.md
+++ b/.claude/scheduling/cloud-routines.md
@@ -50,7 +50,7 @@ runs, but produces an empty result. Verify before you trust the schedule.
 
 ## What to schedule
 
-The rituals this chassis ships, on a weekday loop:
+The rituals this chassis ships, on a weekday loop plus a monthly readout:
 
 | Routine | Schedule | Cron (routine's local tz) |
 |---|---|---|
@@ -58,6 +58,7 @@ The rituals this chassis ships, on a weekday loop:
 | [`/midday-checkin`](../commands/midday-checkin.md) | Weekdays, midday | `0 14 * * 1-5` |
 | [`/end-of-day`](../commands/end-of-day.md) | Weekdays, late afternoon | `30 17 * * 1-5` |
 | [`/weekly-review`](../commands/weekly-review.md) | Friday, late afternoon | `0 16 * * 5` |
+| [`/retention-report`](../commands/retention-report.md) | Monthly, first business day | `0 16 1 * *` |
 
 > Cron in a routine is evaluated in the **routine's own timezone**, not UTC — set
 > the timezone to `<your timezone, e.g. Europe/London>` and use clock times directly.

--- a/.claude/skills/account-health/SKILL.md
+++ b/.claude/skills/account-health/SKILL.md
@@ -15,8 +15,8 @@ From `ops/customers.md` (or a single account the user names) and any recent post
    - 🟡 **Amber** — one warning sign (a stalled workflow, a quiet month, a single thread).
    - 🔴 **Red** — value not landing: usage down, champion gone quiet, or single-threaded after a change.
 3. **Watch the renewal clock.** The renewal motion starts at **day 60**, not day 85. If the renewal date is inside 60 days, say so and start the motion now — don't wait for the contract to surface it.
-4. **Flag churn early-warnings.** Name the leading indicators, not the lagging one: usage trending down, the champion gone quiet, a single-threaded account after a reorg. These precede a lost renewal; the cancellation is just when it becomes visible.
-5. **Spot expansion-readiness.** A healthy account using the core well, or a second team asking unprompted, is an expansion signal — not a renewal risk.
+4. **Flag churn early-warnings.** Name the leading indicators, not the lagging one: usage trending down, the champion gone quiet, a single-threaded account after a reorg. These precede a lost renewal; the cancellation is just when it becomes visible. When one fires, hand the recovery to `churn-save`.
+5. **Spot expansion-readiness.** A healthy account using the core well, or a second team asking unprompted, is an expansion signal — not a renewal risk. Work it with `expansion-play`.
 6. **Write the signal to the loop and update the book.** Log a tagged line in the same feedback log marketing and product read:
    - `RETENTION-RISK: [account] — [the adoption/churn signal] → [CS or product action]`
    - `EXPANSION-SIGNAL: [account] — [the readiness signal] → hand to sales with CS context`

--- a/.claude/skills/churn-save/SKILL.md
+++ b/.claude/skills/churn-save/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: churn-save
+description: Turn a red/amber account into a recovery play — the real risk, the re-engagement outreach, the renewal-clock timing. Trigger when account-health flags a 🔴/🟡 account, when the user says "save this account", "they're going to churn", "the customer went quiet", "renewal at risk", or right after a RETENTION-RISK line is logged.
+---
+
+# Churn Save
+
+The act-skill on the right side of the bowtie. `account-health` *detects* — it scores the account and writes the `RETENTION-RISK` line; this one *acts* on it. The split mirrors the left side, where `lead-qualify` scores and the pursuit skills work the deal. A save is re-earning the outcome the customer bought — not sending a warmer email.
+
+From the at-risk row in `ops/customers.md`, the `RETENTION-RISK` line that flagged it, and any recent notes:
+
+1. **Name the real risk, not the symptom.** The cancellation is the lagging indicator; the cause is upstream — usage trending down, the champion gone quiet, a single-threaded account after a reorg, or the value the deal was sold on never landing. Separate the one that's actually moving from the noise.
+2. **Time the motion.** The renewal clock starts at **day 60**, not day 85. If the renewal date is inside 60 days, the save runs now, in parallel with the renewal — don't let the contract surface the risk for you.
+3. **Re-thread if it's single-threaded.** If one name carried the account and that name went quiet, the save is a *second* relationship, not a better message to the first. Name who else to reach, and why they'd care.
+4. **Draft the re-engagement.** Lead with their outcome — the metric the deal was bought to move — not "just checking in". One concrete next step, with a date. Offer to debrief any reply with `follow-up`.
+5. **Route the cause if it's a product gap.** If a missing capability is what's blocking value, that's a `RETENTION-RISK` / `FEATURE-REQUEST` for product — hand it on with `product-signal` so the save and the roadmap move together (handoff H4 in [`docs/operating-model.md`](../../../docs/operating-model.md)).
+6. **Log the play and update the book.** Record the play and its outcome; update the account's stage, signal, and next step in `ops/customers.md`. If it's lost anyway, log the *real* reason — `/retention-report`'s churn-by-reason read depends on it.
+
+Don't paper a value miss over with a nicer email; a save the customer can see through costs you the reference too. And don't tag every quiet week as a churn — a book full of false alarms gets ignored.
+
+## Depth
+- quick: the real risk + the one next move.
+- standard: the full play above — risk, timing, re-thread, the re-engagement draft, routed cause.
+- deep: + the internal escalation note and the day-by-day renewal-motion timing to the renewal date.

--- a/.claude/skills/expansion-play/SKILL.md
+++ b/.claude/skills/expansion-play/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: expansion-play
+description: Work an expansion-ready account into an angle and a clean hand to sales — the second growth motion the funnel forgets. Trigger when account-health flags an EXPANSION-SIGNAL, when a healthy account asks for more unprompted, a second team wants access, or the user says "this account is ready to grow", "expansion play", "upsell", or "land and expand".
+---
+
+# Expansion Play
+
+The other act-skill on the right side. Two of the three ways a company grows happen after the first sale ([`docs/operating-model.md`](../../../docs/operating-model.md)), and this is one of them: `account-health` flags the `EXPANSION-SIGNAL`; this turns it into an angle and hands it to sales with the customer context attached — so it isn't a cold internal restart.
+
+From the healthy account in `ops/customers.md` and the `EXPANSION-SIGNAL` line:
+
+1. **Confirm the trigger is real.** Expansion rides on *adoption*, not the calendar. The signal is the core used well plus a named next pain — a second team asking unprompted, a new use case, more seats. A renewal date is not an expansion trigger; pushing growth on an account that isn't getting value yet is churn with extra steps.
+2. **Name the angle.** Which way does it grow — an adjacent team, a new use case, deeper use of what they already have? Is it cross-sell (a new thing) or more of the same (more seats, more volume)? One angle, named.
+3. **Build the case on realized value.** Start from what they've already gotten — the outcome the book can show — and extend it to the new area, in their words, not a feature list.
+4. **Re-arm the champion.** Expansion is carried internally, not pitched in. Give the champion the one-page case they can forward, and the line that makes it their idea — not your quota.
+5. **Hand to sales with the CS context.** The handoff is the account, the angle, the realized-value case, and the champion — so sales picks up a warm, qualified expansion, not a cold account. A real expansion is a new deal: it crosses back to `ops/pipeline.md`, the loop the bowtie closes.
+6. **Log it and update the book.** Mark the account Expanding; note the angle and the handoff in `ops/customers.md`.
+
+Don't run this on an unhealthy account — route that to `churn-save` first. Expansion is the reward for value landing, not a substitute for it.
+
+## Depth
+- quick: confirm the trigger + name the one angle.
+- standard: the full play — trigger, angle, value-case, champion, hand to sales.
+- deep: + the multi-thread map of who signs off on the larger spend, and the buyer-facing one-pager for the champion to forward.

--- a/.claude/skills/onboarding-handoff/SKILL.md
+++ b/.claude/skills/onboarding-handoff/SKILL.md
@@ -10,10 +10,10 @@ The handoff most teams never define: a signed deal drops silently into a custome
 From the won deal (point me at the row in `ops/pipeline.md`, or paste the deal context):
 
 1. **Carry the value hypothesis forward.** Write down, in one line, what the customer bought this to do — in their words, from discovery. This becomes the value hypothesis in `ops/customers.md`, and the thing every adoption check is measured against. Lose it here and onboarding optimizes for activity, not value.
-2. **Set the date markers.** Record the renewal date and note the **day-60** renewal-motion trigger (not day-85). Set a first-expansion check date too — the moment to look for a second team or use case.
+2. **Set the date markers.** Record the renewal date, the contract value (ARR — the number the book rolls up to NRR), and note the **day-60** renewal-motion trigger (not day-85). Set a first-expansion check date too — the moment to look for a second team or use case.
 3. **Identify the power user / champion.** Name who will actually use it and who sponsors it internally. A single-threaded account is a churn risk before it's even live — if there's only one name, that's the first gap to close.
 4. **Write the first adoption milestone.** One concrete, dated outcome that proves value is landing (the first workflow live, the first cross-system answer, the first report shipped). Vague onboarding has no finish line.
-5. **Open the row.** Create the account in `ops/customers.md` at stage **Onboarding**, with the value hypothesis, the first adoption signal to watch, the renewal date, an owner, and the next step. Offer to log the handoff in `ops/daily-log.md`.
+5. **Open the row.** Create the account in `ops/customers.md` at stage **Onboarding**, with the value hypothesis, the ARR, the first adoption signal to watch, the renewal date, an owner, and the next step. Offer to log the handoff in `ops/daily-log.md`.
 
 Don't invent commitments the deal didn't contain. Bring your own onboarding playbook; this carries the deal's context across the seam so nothing drops.
 

--- a/.claude/skills/qbr-prep/SKILL.md
+++ b/.claude/skills/qbr-prep/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: qbr-prep
+description: Turn a customer's recent calls, adoption signal, and roadmap status into a QBR brief that leads with the outcome they bought. Trigger when a quarterly business review is coming up, before a renewal or value-review call, or when the user says "QBR prep", "build the QBR", "quarterly review for X", or "value review".
+---
+
+# QBR Prep
+
+The recurring right-side ritual. A QBR isn't a status meeting or a feature tour — it's a *value-realization review*: did the customer get the outcome they bought, and what's the next one? This assembles the brief from what's already in the repo, so the review leads with their metric, not your release notes.
+
+From the account in `ops/customers.md`, its recent meeting notes (in `ops/` or `demo/meetings/`), and `ops/roadmap-signals.md`:
+
+1. **Outcome recap — lead here.** State the value hypothesis the deal was bought on, then the evidence it's landing: the adoption signal, what's live, who's using it. Their metric, their words. This is the spine of the brief; everything else hangs off it.
+2. **Risks, named first.** What isn't landing yet — a stalled workflow, a quiet stretch, a single-threaded relationship — said before the customer raises it. Naming the gap yourself is what makes the recap credible.
+3. **What shipped for them.** Pull anything in `ops/roadmap-signals.md` tied to this account that's now Shipped, with its buyer-facing line. "You asked, we shipped" closes the loop the customer started (handoff H5 in [`docs/operating-model.md`](../../../docs/operating-model.md)) and earns the next ask.
+4. **The next desired outcome.** Frame the expansion thesis as *their* next goal — the adjacent team or use case — not a quota. If it's real, this is the seed `expansion-play` works after the QBR.
+5. **One ask, one offer.** A single ask (a reference, a case study, an intro) and a single offer (an expansion, a new team, a deeper rollout). More than one of each dilutes both.
+
+Output a brief you can walk in with. Don't invent outcomes the notes don't support — a QBR that claims value the customer didn't feel is the fastest way to lose the renewal.
+
+## Depth
+- quick: the one-page brief — outcome recap, top risk, the one ask.
+- standard: the full brief above, ready to present from.
+- deep: + a slide-ready outline to hand to a deck tool, and the expansion thesis written up for `expansion-play`.

--- a/.claude/skills/support-signal/SKILL.md
+++ b/.claude/skills/support-signal/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: support-signal
+description: Cluster a batch of support tickets or threads into ranked product themes, then hand them to product-signal for the roadmap. Trigger when there's a pile of support tickets, or the user says "what are the tickets telling us", "cluster these tickets", "support themes", "top issues this month", or wants raw support volume turned into product feedback.
+---
+
+# Support Signal
+
+The front-end to `product-signal`. A roadmap fed by raw tickets is noise; this clusters the volume into a few ranked themes first, so what reaches product is a pattern, not a pile. It reads a batch of tickets — from a support tool over MCP, or a pasted / `demo/support-tickets.md` list — and emits the themes `product-signal` routes.
+
+From the batch:
+
+1. **Cluster by the underlying job, not the wording.** Group tickets by what the customer was trying to do, not the words they used — three phrasings of "I can't get the data out" are one theme.
+2. **Rank by frequency × severity.** How many accounts raised it, and how much it hurts — is it blocking adoption or a renewal, or is it a papercut? A one-off annoyance isn't a theme; a recurring blocker is. Rank the themes; don't route a flat list.
+3. **Split the types.** Each theme is one of: **adoption friction** (a setup or UX gap — product), **feature request** (a missing capability — roadmap), **bug** (it's broken — engineering), or **how-to** (they couldn't find it — an *enablement / docs* gap, not a product one). The how-to pile is a signal too: it's where onboarding or the docs are failing.
+4. **Tie themes to accounts.** Name which customers each theme touches — especially any tied to a renewal or an expansion. That tie is what lifts a theme above raw count.
+5. **Hand the top themes to `product-signal`.** Emit each as a line it can triage into `ops/roadmap-signals.md` — `FEATURE-REQUEST` or adoption-friction, with the account tie — so the clustering and the routing compose into one loop (handoff H4 in [`docs/operating-model.md`](../../../docs/operating-model.md)).
+
+Don't route every ticket; cluster first, route the pattern. The point is to turn volume into a short, ranked list product can actually act on.
+
+## Depth
+- quick: the top 3 themes, ranked, with counts.
+- standard: the full clustering above — themes ranked, typed, tied to accounts, handed to product-signal.
+- deep: + the how-to / enablement split (the themes that are really a docs or onboarding gap, routed there instead) and a buyer-facing line for any theme already shipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Retention act-skills — the right side gets more than a detector**
+  (`.claude/skills/`): `churn-save` (recover a red/amber account — the real risk,
+  the re-engagement draft, the renewal-clock timing), `expansion-play` (work a
+  ready-to-grow account into an angle and a clean hand to sales), `qbr-prep`
+  (assemble a value-realization QBR brief from the book, recent notes, and roadmap
+  status), and `support-signal` (cluster a batch of support tickets into ranked
+  product themes, then hand them to `product-signal`). `account-health` now hands
+  off to `churn-save` / `expansion-play`; together they close the customer-success
+  playbook on the right side of the bowtie.
+- **`/retention-report` command** (`.claude/commands/retention-report.md`) — a
+  monthly readout that rolls the customer book up to NRR and GRR (formulae named,
+  computed from the `ARR` column over git history), churn by reason, and expansion,
+  then writes next month's two bets to `ops/priorities.md`. Scheduled monthly in
+  `.claude/scheduling/cloud-routines.md`.
+- **`ARR` column in the customer book** (`ops/customers.md`, `demo/customers.md`) —
+  the recurring revenue that rolls up to NRR, captured at the `onboarding-handoff`
+  seam so `/retention-report` can compute it. Seeded in the demo data, alongside a
+  `demo/support-tickets.md` batch and a `demo/meetings/` value-review note so the
+  new skills run against realistic data out of the box.
 - **Cloud Routines scheduling** (`.claude/scheduling/`) — a runbook for running the
   rituals on Anthropic-managed infrastructure without your machine awake
   (`cloud-routines.md`), plus a three-layer scheduling overview (OS scheduler vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status), and `support-signal` (cluster a batch of support tickets into ranked
   product themes, then hand them to `product-signal`). `account-health` now hands
   off to `churn-save` / `expansion-play`; together they close the customer-success
-  playbook on the right side of the bowtie.
+  playbook on the right side of the bowtie. (#39)
 - **`/retention-report` command** (`.claude/commands/retention-report.md`) — a
   monthly readout that rolls the customer book up to NRR and GRR (formulae named,
   computed from the `ARR` column over git history), churn by reason, and expansion,
   then writes next month's two bets to `ops/priorities.md`. Scheduled monthly in
-  `.claude/scheduling/cloud-routines.md`.
+  `.claude/scheduling/cloud-routines.md`. (#39)
 - **`ARR` column in the customer book** (`ops/customers.md`, `demo/customers.md`) —
   the recurring revenue that rolls up to NRR, captured at the `onboarding-handoff`
   seam so `/retention-report` can compute it. Seeded in the demo data, alongside a
   `demo/support-tickets.md` batch and a `demo/meetings/` value-review note so the
-  new skills run against realistic data out of the box.
+  new skills run against realistic data out of the box. (#39)
 - **Cloud Routines scheduling** (`.claude/scheduling/`) — a runbook for running the
   rituals on Anthropic-managed infrastructure without your machine awake
   (`cloud-routines.md`), plus a three-layer scheduling overview (OS scheduler vs

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Nothing there is real — delete `demo/` whenever you like.
 | Piece | What it is |
 |---|---|
 | `.claude/hooks/` | Five guardrails: session-start context, **state re-injection across compaction**, a **commit secret-guard**, sensitive-file protection, an end-of-day nudge — plus a **web-session bootstrap** that installs the hook linter (`shellcheck`) on remote / Claude-Code-on-the-web containers |
-| `.claude/commands/` | Daily rituals you invoke by name: `/morning-briefing`, `/midday-checkin`, `/end-of-day`, `/weekly-review`, plus `/demo-briefing` |
+| `.claude/commands/` | Daily rituals you invoke by name: `/morning-briefing`, `/midday-checkin`, `/end-of-day`, `/weekly-review`, the monthly `/retention-report`, plus `/demo-briefing` |
 | `.claude/skills/` | Skill templates grouped by the four growth functions (see below) — so the balance across marketing, sales, product, and retention is visible, not acquisition-only |
 | `.claude/rules/` | Standing constraints every session honors — how to reach a CRM over MCP (`crm-usage.md`) and how the to-do list renders one canonical way (`todo-single-source.md`); obeyed by interactive rituals and autonomous routines alike |
 | `.claude/scheduling/` | Run the rituals on a clock — locally (cron/launchd), as **cloud Routines** (no machine awake), or as a CI backstop (the deterministic checks in `.claude/scripts/checks/`, run by a GitHub Actions `schedule:`). Full runbook in `cloud-routines.md` |
@@ -75,8 +75,8 @@ Nothing there is real — delete `demo/` whenever you like.
 |---|---|
 | **Marketing / Demand** | `content-repurpose`, `marketing-feedback` (sales→marketing loop) |
 | **Sales** | `lead-qualify`, `meeting-prep`, `follow-up`, `cold-outreach` |
-| **Product** | `product-signal` (routes field + retention signals to the roadmap; writes the buyer-facing line for anything shipped) |
-| **Retention** | `onboarding-handoff` (Won→onboarding), `account-health` (adoption, renewal motion, churn/expansion), `retention-feedback` (post-sale→product loop) |
+| **Product** | `support-signal` (clusters support tickets into ranked themes), `product-signal` (routes those + field/retention signals to the roadmap; writes the buyer-facing line for anything shipped) |
+| **Retention** | `onboarding-handoff` (Won→onboarding), `account-health` (scores adoption, renewal motion, churn/expansion), `churn-save` (recover an at-risk account), `expansion-play` (work a ready-to-grow account), `qbr-prep` (the value-realization review), `retention-feedback` (post-sale→product loop) |
 | **Cross-cutting** | `status-update`, `triage`, `calendar-followup` (unfinished follow-ups from last week's meetings), `inbox-digest` (unread newsletter digest) |
 
 ## How it fits together
@@ -85,8 +85,8 @@ One loop, all plain text in git:
 
 1. **Open a session** → the SessionStart hook surfaces today's priorities.
 2. **`/morning-briefing`** reads your priorities, yesterday's log, and your pipeline → today's top three.
-3. **Through the day**, the skills work on your own data, on both sides of the bowtie. *Left side:* `lead-qualify` a new opportunity, `meeting-prep` before a call, `follow-up` after it, `cold-outreach` to a prospect, `content-repurpose` a win into posts, `marketing-feedback` to turn a recurring objection into a note marketing acts on. *Right side:* `onboarding-handoff` when a deal is won (carry the value hypothesis across the seam), `account-health` to score adoption and start the renewal motion at day 60, `product-signal` to route retention and field signals to the roadmap, and `retention-feedback` to turn an adoption slip into a signal product acts on.
-4. **`/end-of-day`** logs what shipped and sets tomorrow; **`/weekly-review`** finds the patterns across both sides — renewals due, accounts at risk, expansion candidates, and the top roadmap signals.
+3. **Through the day**, the skills work on your own data, on both sides of the bowtie. *Left side:* `lead-qualify` a new opportunity, `meeting-prep` before a call, `follow-up` after it, `cold-outreach` to a prospect, `content-repurpose` a win into posts, `marketing-feedback` to turn a recurring objection into a note marketing acts on. *Right side:* `onboarding-handoff` when a deal is won (carry the value hypothesis across the seam), `account-health` to score adoption and start the renewal motion at day 60 — then `churn-save` to recover a slipping account, `expansion-play` to work one that's ready to grow, and `qbr-prep` to run the value-realization review; `support-signal` to cluster support tickets into themes, `product-signal` to route those and the field signals to the roadmap, and `retention-feedback` to turn an adoption slip into a signal product acts on.
+4. **`/end-of-day`** logs what shipped and sets tomorrow; **`/weekly-review`** finds the patterns across both sides — renewals due, accounts at risk, expansion candidates, and the top roadmap signals; **`/retention-report`** rolls the customer book up to NRR/GRR once a month.
 5. **The hooks hold it together** — your state survives a long session (`pre-compact`), and nothing secret slips into a commit (`pre-commit-guard`).
 
 The left side lives in `ops/pipeline.md`; the right side in `ops/customers.md` (the post-sale account book) and `ops/roadmap-signals.md` (product's triage queue). Priorities and notes round it out — all yours, with a fictional copy in `demo/`. Edit the markdown, commit, and your whole go-to-market has a history. The handoffs that connect the four functions are mapped in [`docs/operating-model.md`](docs/operating-model.md).

--- a/demo/customers.md
+++ b/demo/customers.md
@@ -6,11 +6,12 @@
 >
 > Stage: Onboarding → Adopting → Live → At-Risk → Expanding. The renewal motion
 > starts at **day 60**, not day 85 — the renewal date is the clock to watch.
+> `ARR` is the recurring revenue that rolls up to NRR — what `/retention-report` reads.
 
-| Account | Stage | Value hypothesis | Key adoption signal | Renewal date | Owner | Next step |
-|---|---|---|---|---|---|---|
-| Northwind Robotics | 🔴 At-Risk | Cut cross-system lookup time for ops engineers | Usage down 2 weeks; 1 of 3 workflows live; champion quiet after reorg | 2026-09-30 | CS | Re-map stakeholders, find a power user — renewal clock opens day 60 |
-| Halden Maritime | 🟡 At-Risk | One view of vessel data across port systems | Steady usage, but renewal case blocked on a missing export feature | 2026-07-15 | CS | Chase roadmap status on export; renewal motion already open (inside day 60) |
-| Cascadia BioSciences | 🟢 Adopting | Answer cross-system research questions in minutes | Two analysts onboarded; first workflow live, second in setup | 2026-11-30 | CS | Confirm second workflow milestone; watch for the day-60 marker |
-| Meridian Health | 🟢 Expanding | Connect clinical data across departments | Healthy in the first department; a second asked for access unprompted | 2026-10-31 | CS + Sales | Hand expansion signal to sales with the CS context attached |
-| Thornbury Insurance | 🟢 Onboarding | One compliance view across two business contexts | Kickoff done; first context being configured; champion engaged | 2026-12-15 | CS | Set first adoption milestone; carry the two-context value hypothesis forward |
+| Account | Stage | Value hypothesis | Key adoption signal | Renewal date | ARR | Owner | Next step |
+|---|---|---|---|---|---|---|---|
+| Northwind Robotics | 🔴 At-Risk | Cut cross-system lookup time for ops engineers | Usage down 2 weeks; 1 of 3 workflows live; champion quiet after reorg | 2026-09-30 | $66,000 | CS | Re-map stakeholders, find a power user — renewal clock opens day 60 |
+| Halden Maritime | 🟡 At-Risk | One view of vessel data across port systems | Steady usage, but renewal case blocked on a missing export feature | 2026-07-15 | $54,000 | CS | Chase roadmap status on export; renewal motion already open (inside day 60) |
+| Cascadia BioSciences | 🟢 Adopting | Answer cross-system research questions in minutes | Two analysts onboarded; first workflow live, second in setup | 2026-11-30 | $90,000 | CS | Confirm second workflow milestone; watch for the day-60 marker |
+| Meridian Health | 🟢 Expanding | Connect clinical data across departments | Healthy in the first department; a second asked for access unprompted | 2026-10-31 | $78,000 | CS + Sales | Hand expansion signal to sales with the CS context attached |
+| Thornbury Insurance | 🟢 Onboarding | One compliance view across two business contexts | Kickoff done; first context being configured; champion engaged | 2026-12-15 | $60,000 | CS | Set first adoption milestone; carry the two-context value hypothesis forward |

--- a/demo/meetings/2026-05-21-meridian-health-check-in.md
+++ b/demo/meetings/2026-05-21-meridian-health-check-in.md
@@ -1,0 +1,29 @@
+---
+type: meeting
+title: Meridian Health — value review / check-in
+date: 2026-05-21
+participants: [You, Dr. Anita Rao (Clinical Data Lead, Meridian Health)]
+---
+
+# Meridian Health — value review / check-in (2026-05-21)
+
+> Fictional sample meeting note — input for `qbr-prep`.
+
+## Summary
+Quarterly check-in with the first department (clinical data). Anita confirmed the
+team now answers cross-system research questions in minutes that used to take a
+half-day of manual lookups — the outcome the deal was bought on. A second
+department (population health) asked her, unprompted, for access after seeing a
+shared report.
+
+## Value signals
+- First workflow fully adopted; ~15 analysts active weekly.
+- Her metric: cross-system question turnaround down from ~half a day to minutes.
+- Willing to be a reference once the second department is live.
+
+## Risks / open
+- Saved-views feature shipped, but the team hadn't found it — a quick enablement gap.
+- Wants the connected view to push into their BI dashboard eventually.
+
+## Next step
+QBR in three weeks; bring the expansion path for population health.

--- a/demo/support-tickets.md
+++ b/demo/support-tickets.md
@@ -1,0 +1,33 @@
+# Support Tickets — sample data
+
+> Every ticket below is fictional, across the same made-up accounts as
+> `demo/customers.md`. This is a raw batch — the kind `support-signal` clusters
+> into a few ranked themes before `product-signal` routes them to
+> `demo/roadmap-signals.md`. Delete the whole `demo/` folder when you make this yours.
+
+| # | Date | Account | Ticket (as the customer wrote it) | First-pass type |
+|---|---|---|---|---|
+| 1 | 2026-05-18 | Northwind Robotics | "Stuck setting up the second workflow — the connector step errors out and we gave up." | Adoption friction |
+| 2 | 2026-05-19 | Cascadia BioSciences | "Second workflow setup is confusing — which source do we map first?" | Adoption friction |
+| 3 | 2026-05-20 | Thornbury Insurance | "Onboarding: the data-connector step isn't clear, we're blocked configuring the first context." | Adoption friction |
+| 4 | 2026-05-17 | Halden Maritime | "Still need to export the connected view to our reporting tool — any update?" | Feature request |
+| 5 | 2026-05-21 | Halden Maritime | "Can't sign off the renewal until we can get this data out to Power BI." | Feature request |
+| 6 | 2026-05-15 | Meridian Health | "Is there a way to push the connected view into our BI dashboard?" | Feature request |
+| 7 | 2026-05-16 | Cascadia BioSciences | "How do I save a view so I don't rebuild the query every morning?" | How-to |
+| 8 | 2026-05-19 | Meridian Health | "Where's the saved-views feature you shipped? Can't find it." | How-to |
+| 9 | 2026-05-14 | Northwind Robotics | "SSO login dropped us twice this week." | Bug |
+| 10 | 2026-05-20 | Thornbury Insurance | "Can we add a second admin user?" | How-to |
+| 11 | 2026-05-13 | Cascadia BioSciences | "Export to CSV timed out on a large result." | Bug |
+| 12 | 2026-05-18 | Meridian Health | "Second department wants access — how do we add them?" | How-to |
+
+<!-- This batch clusters cleanly, which is the point of the demo:
+     - Tickets 1–3 = the second-workflow / connector setup step (adoption friction,
+       three accounts) — confirms the Northwind roadmap signal and widens it.
+     - Tickets 4–6 = export the connected view to a BI tool (feature request, tied
+       to Halden's renewal) — the highest-priority theme.
+     - Tickets 7–8 = saved views, a feature already Shipped — so these are an
+       *enablement / docs* gap, not a new build.
+     - Tickets 9, 11 = bugs (engineering, not roadmap).
+     - Tickets 10, 12 = how-to — and #12 is really an EXPANSION-SIGNAL hiding in a
+       support ticket (Meridian's second department), which support-signal should
+       surface, not bury. -->

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -58,8 +58,8 @@ You don't need a platform — a plain-text repo run from Claude Code *is* the op
 
 - **One source of truth** → the git repo. Every function reads and writes the same markdown.
 - **The handoffs** → `ops/pipeline.md` (H1), the feedback log (H2, H6), `ops/customers.md` (H3), `ops/roadmap-signals.md` (H4, H5).
-- **The skills** → `marketing-feedback` (H2), `onboarding-handoff` (H3), `account-health` (the right-side operating loop), `product-signal` (H4/H5), `retention-feedback` (the post-sale→product loop).
-- **The rituals** → `/demo-briefing` and `/weekly-review` run the joint motion and close the loop (L) across all four.
+- **The skills** → `marketing-feedback` (H2), `onboarding-handoff` (H3), `account-health` (the right-side detector) handing to `churn-save`, `expansion-play`, and `qbr-prep` (the act-skills), `support-signal` → `product-signal` (H4/H5), `retention-feedback` (the post-sale→product loop).
+- **The rituals** → `/demo-briefing` and `/weekly-review` run the joint motion and close the loop (L) across all four; `/retention-report` rolls the book up to NRR/GRR monthly.
 
 The mature version of this is RevOps — one operating model and one data spine for the whole motion. At a founder-led stage the fix is to *close the loop*, not to hire a RevOps team: keep all four functions learning in one place and document the motion before you delegate it.
 

--- a/ops/customers.md
+++ b/ops/customers.md
@@ -2,12 +2,13 @@
 
 <!-- The post-sale account book — one row per signed customer.
      Stage: Onboarding → Adopting → Live → At-Risk → Expanding.
+     ARR is the recurring revenue that rolls up to NRR — what /retention-report reads.
      The renewal motion starts at day 60, not day 85. -->
 
-| Account | Stage | Value hypothesis | Key adoption signal | Renewal date | Owner | Next step |
-|---|---|---|---|---|---|---|
-| Halcyon Foods | 🟢 Onboarding | One view of supply-chain data across plants | Kickoff done; 1 of 3 workflows live | 2027-02-28 | CS | Set the second-workflow milestone |
-| Nordvik Maritime | 🔴 At-Risk | Unify vessel telemetry across ports | Usage down 3 weeks; champion left; export gap blocking renewal | 2026-07-10 | CS | Re-map stakeholders; open the renewal motion |
-| Pinnacle Health Group | 🟢 Adopting | Connect clinical data across departments | Two departments live; third in setup | 2026-09-15 | CS | Confirm the third-department milestone |
-| Ardent Insurance | 🟢 Expanding | One compliance view across lines of business | Healthy; a second line of business requested access | 2026-11-30 | CS + Sales | Hand the expansion signal to sales |
-| Tilbury Manufacturing | 🟢 Live | Real-time OEE across the floor | Steady; all workflows adopted | 2026-08-20 | CS | Book the QBR; line up a reference ask |
+| Account | Stage | Value hypothesis | Key adoption signal | Renewal date | ARR | Owner | Next step |
+|---|---|---|---|---|---|---|---|
+| Halcyon Foods | 🟢 Onboarding | One view of supply-chain data across plants | Kickoff done; 1 of 3 workflows live | 2027-02-28 | $48,000 | CS | Set the second-workflow milestone |
+| Nordvik Maritime | 🔴 At-Risk | Unify vessel telemetry across ports | Usage down 3 weeks; champion left; export gap blocking renewal | 2026-07-10 | $60,000 | CS | Re-map stakeholders; open the renewal motion |
+| Pinnacle Health Group | 🟢 Adopting | Connect clinical data across departments | Two departments live; third in setup | 2026-09-15 | $90,000 | CS | Confirm the third-department milestone |
+| Ardent Insurance | 🟢 Expanding | One compliance view across lines of business | Healthy; a second line of business requested access | 2026-11-30 | $72,000 | CS + Sales | Hand the expansion signal to sales |
+| Tilbury Manufacturing | 🟢 Live | Real-time OEE across the floor | Steady; all workflows adopted | 2026-08-20 | $54,000 | CS | Book the QBR; line up a reference ask |


### PR DESCRIPTION
## Summary

The right side of the bowtie had a **detector** (`account-health`) and the two **loops** (`retention-feedback`, `product-signal`) — but no **act-skills** for the post-sale growth motions, and no NRR/GRR readout. This closes the customer-success playbook with the same detect→act depth the left side already has.

**New skills (`.claude/skills/`):**
- **`churn-save`** — recover a 🔴/🟡 account: the real risk, the re-engagement draft, the renewal-clock timing. `account-health` now hands off to it.
- **`expansion-play`** — work a ready-to-grow account into an angle and a clean hand to sales. `account-health` hands off to it too.
- **`qbr-prep`** — assemble a value-realization QBR brief from the book, recent notes, and roadmap status (leads with the outcome, not a feature tour).
- **`support-signal`** — cluster a batch of support tickets into ranked product themes, then hand them to `product-signal` (it's the front-end that skill was missing).

**New ritual:**
- **`/retention-report`** — monthly NRR/GRR (formulae named, computed from the new `ARR` column over git history), churn by reason, expansion, and next month's two bets. Scheduled monthly in `cloud-routines.md`.

**Customer book:**
- **`ARR` column** on `ops/customers.md` + `demo/customers.md`, captured at the `onboarding-handoff` seam so the report can compute the one number.
- `demo/support-tickets.md` and a `demo/meetings/` value-review note so the new skills run against realistic data out of the box.

Wired into the README (skills-by-function, how-it-fits), `docs/operating-model.md`, scheduling, and CHANGELOG.

## Why

Each new skill closes one of six common customer-success jobs that previously had no home (churn outreach, expansion angle, QBR, support→themes) or only a count-based proxy (the retention report). Notes→action-items and churn/expansion *detection* were already covered by `follow-up`/`calendar-followup` and `account-health`, so those weren't duplicated — the gaps were the *act* skills and the *number*.

## Test plan

- [x] `bash .claude/scripts/checks/growth-os-checks.sh` → **PASS, 0 hard / 0 soft** (structure, freshness, all relative links resolve).
- [ ] Run `/demo-briefing`, then try `support-signal` on `demo/support-tickets.md` (clusters to export-to-BI + connector-setup themes; flags ticket #12 as a hidden expansion signal), `qbr-prep` on Meridian Health, `churn-save` on Northwind/Halden, `expansion-play` on Meridian.
- [ ] Run `/retention-report` against `demo/customers.md` (now carries `ARR`).

🤖 Draft — opened for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MDF26Ft4EC2i75rD4WscS)_