### PR TITLE
Add the loop's verify step: hook, CRM guardrail, and loop-design docs

### DIFF
--- a/.claude/hooks/verify-after-change.sh
+++ b/.claude/hooks/verify-after-change.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# PostToolUse(Edit|Write): the loop's "verify" step, as a hook.
+#
+# Guardrails (protect-files) stop a bad write *before* it happens; this checks the
+# work *after* it lands — the other half of a closed loop. Advisory only: it warns,
+# never blocks (exit 0 always). Two checks, both dependency-light:
+#   1. Broken relative links in the changed markdown file (this kit is markdown-first).
+#   2. Your project's own verifier, if you supply one at .claude/scripts/verify.sh
+#      (copy verify.sh.example to wire `make check`, `npm test`, `pytest`, the
+#      checks/ dir, etc.).
+#
+# Keep it advisory. A verify step you dread is a verify step you'll disable.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+INPUT=$(cat)
+
+# Match the kit convention: read the hook payload with python3, not jq.
+FILE_PATH=$(printf '%s' "$INPUT" | python3 -c \
+  'import sys, json; print(json.load(sys.stdin).get("tool_input", {}).get("file_path", ""))' \
+  2>/dev/null || true)
+
+WARNED=0
+
+# --- Check 1: broken relative links in a changed markdown file ------------
+case "$FILE_PATH" in
+  *.md)
+    if [ -f "$FILE_PATH" ]; then
+      link_dir=$(dirname "$FILE_PATH")
+      while IFS= read -r target; do
+        [ -z "$target" ] && continue
+        clean=${target%%#*}   # strip anchor
+        clean=${clean%%\?*}   # strip query
+        [ -z "$clean" ] && continue
+        case "$clean" in
+          http:*|https:*|mailto:*|tel:*) continue ;;
+          /*) resolved="$clean" ;;
+          *)  resolved="$link_dir/$clean" ;;
+        esac
+        if [ ! -e "$resolved" ]; then
+          [ "$WARNED" -eq 0 ] && { echo "verify-after-change: $FILE_PATH" >&2; WARNED=1; }
+          echo "  - broken link: $target" >&2
+        fi
+      done < <(grep -oE '\]\([^)]+\)' "$FILE_PATH" 2>/dev/null | sed -E 's/^\]\(//; s/\)$//' || true)
+    fi
+    ;;
+esac
+
+# --- Check 2: the project's own verifier, if supplied ---------------------
+VERIFY="$PROJECT_DIR/.claude/scripts/verify.sh"
+if [ -x "$VERIFY" ]; then
+  if command -v timeout >/dev/null 2>&1; then
+    CHECK_OUT=$(timeout 60 "$VERIFY" "$FILE_PATH" 2>&1) || CHECK_FAILED=1
+  else
+    CHECK_OUT=$("$VERIFY" "$FILE_PATH" 2>&1) || CHECK_FAILED=1
+  fi
+  if [ "${CHECK_FAILED:-0}" -eq 1 ]; then
+    [ "$WARNED" -eq 0 ] && { echo "verify-after-change: project check reported issues" >&2; WARNED=1; }
+    printf '%s\n' "${CHECK_OUT:-}" | sed 's/^/  /' >&2
+  fi
+fi
+
+[ "$WARNED" -eq 1 ] && echo "  (advisory — review before commit)" >&2
+exit 0

--- a/.claude/rules/crm-usage.md
+++ b/.claude/rules/crm-usage.md
@@ -55,7 +55,7 @@ Two things bite every time, so make them habits:
 
 These exist because a [cloud routine](../scheduling/cloud-routines.md) runs
 **autonomously** — there's no one to catch a bad write mid-run. Every write obeys
-all six:
+all seven:
 
 1. **Read before write.** Fetch the current value first; decide the change against
    what's actually there, not what you assume is there.
@@ -72,6 +72,12 @@ all six:
    failed field abort the ritual.
 6. **Treat AI-generated / computed fields as read-only.** Scores or summaries the
    CRM writes itself are outputs, not inputs you overwrite.
+7. **Verify the write landed.** After a write, read the value back and reconcile —
+   the field should now hold the new value, and a batch you pushed should match the
+   count you intended. A write you didn't confirm is one you're trusting blind. On a
+   divergence, surface it loudly in the run's output (don't wait for the weekly
+   reconcile) and flag the mirror stale. This is the loop's *verify* step: guardrails
+   1–6 govern the write going in; this one confirms it actually took.
 
 ## Choose your write authority
 

--- a/.claude/scripts/verify.sh.example
+++ b/.claude/scripts/verify.sh.example
@@ -1,0 +1,37 @@
+#!/bin/bash
+# .claude/scripts/verify.sh — your project's "did it work?" check.
+#
+# Copy this to verify.sh and make it executable to wire the loop's verify step:
+#
+#   cp .claude/scripts/verify.sh.example .claude/scripts/verify.sh
+#   chmod +x .claude/scripts/verify.sh
+#
+# verify-after-change.sh runs it after every Edit/Write (advisory, time-boxed to
+# 60s, never blocks), and you can run it by hand any time. Exit non-zero to surface
+# a problem — the hook shows the output; it doesn't stop you.
+#
+# $1 is the file that just changed (may be empty on a manual run). Use it to scope
+# the check to what moved, or ignore it and check the whole repo.
+set -euo pipefail
+CHANGED="${1:-}"
+
+# Wire the checks that fit your project. Uncomment what applies, delete the rest.
+
+# Run the deterministic checks this kit ships (the same ones CI runs):
+#   for c in .claude/scripts/checks/*.sh; do [ -x "$c" ] && "$c"; done
+
+# A Makefile target:
+#   make check
+
+# A JS/TS project:
+#   npm test --silent && npm run lint --silent
+
+# A Python project:
+#   pytest -q && ruff check .
+
+# A markdown-only ops repo: the hook already link-checks the changed file, so you
+# might verify structure instead — e.g. that today's log entry exists, or that
+# ops/pipeline.md still parses.
+
+echo "verify.sh: no checks wired yet — edit .claude/scripts/verify.sh (changed: ${CHANGED:-none})"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,6 +53,14 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-after-change.sh" }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/docs/designing-loops.md
+++ b/docs/designing-loops.md
@@ -1,0 +1,157 @@
+# Designing loops, not prompts
+
+A short argument for the shape underneath this kit: that the thing you design is the
+*loop*, not the prompt.
+
+This page is the *why*. The [methodology](methodology.md) is the *what* (five ideas);
+the commands, hooks, and rules are the *how*. Read this when you want the mental
+model the rest of the kit is built on.
+
+## The shift
+
+The first instinct with a capable model is to write a better instruction. Phrase it
+well, get a better answer. That still helps, but it stopped being where the leverage
+is the moment models could *act* — call a tool, read the result, decide the next
+step. Once an assistant takes steps, whether it succeeds at a multi-step job is
+decided mostly *outside* the prompt: by what it can see, what it can do, and whether
+it can tell that a step worked.
+
+So the work moves up a ladder:
+
+- **Prompt** — word the instruction.
+- **Context** — control what the model sees (history, files, retrieved notes, tool
+  definitions). This kit's "state in plain text, in git" is context engineering.
+- **Loop / harness** — design the cycle the model runs in: the tools, the feedback,
+  the stopping conditions, the human checkpoints.
+
+A single well-worded instruction is table stakes now. The differentiated skill is
+designing the loop the instruction runs inside.
+
+## What an agent actually is
+
+Strip away the vocabulary and a working agent is small: **a model, a set of tools,
+and a loop** that calls the model, lets it act, feeds back what happened, and repeats
+until the work is done. The intelligence lives in the model. The *reliability* lives
+in how you shape that loop.
+
+The loop has a standard shape:
+
+```
+   goal ─▶  gather context  ─▶  act (use a tool)  ─▶  verify the result
+              ▲                                              │
+              └──────────────  repeat until done ◀───────────┘
+                         (or: stop, or: ask a human)
+```
+
+The pieces you actually design:
+
+| Piece | What it is | The question to answer |
+|---|---|---|
+| **Tools** | The actions available — read, write, run, search, call an API | What's the smallest, sharpest set? |
+| **Context** | Everything the model sees this step | What loads always vs. just-in-time? |
+| **The loop** | The control flow that repeats act → observe | Do you own it, or does a framework? |
+| **Verification** | The check after each step | A test? A file that should exist? A count that should match? |
+| **State** | What persists across steps and sessions | In a file, in git, in the ritual's output? |
+| **Termination** | When it stops | Done, budget spent, error ceiling hit, or hand to a human |
+
+Two of these are routinely skipped and cause most of the pain: **verification** and
+**termination**. A loop with no check can't tell progress from confident drift. A
+loop with no stop either spins or quietly does the wrong thing for a while.
+
+## The piece most setups miss: verification
+
+If you build one thing into a ritual, build the check.
+
+An agent is only as good as its ability to tell whether its last step worked. Give it
+something concrete to verify against and it self-corrects across passes; give it
+nothing and quality is a coin flip. Verification comes in a few flavors, cheapest
+first:
+
+- **Rules-based** — a test suite, a linter, a schema validator, a script that exits
+  non-zero. Unambiguous; prefer it.
+- **A factual check** — a file that should now exist, a row count that should match,
+  a value you read back after writing it.
+- **A second opinion** — a model judging the output against a written rubric, for the
+  fuzzy cases code can't score.
+
+In this kit, verification can live in a hook so it runs every time instead of only
+when you remember — that's what `.claude/hooks/verify-after-change.sh` is, and the
+`.claude/scripts/verify.sh.example` template is where you wire your own check (a test
+run, `make check`, the `checks/` scripts). It's the *verify* counterpart to the
+guardrail hooks that already block bad writes.
+
+## A build playbook
+
+When you turn a recurring task into a ritual, design it as a loop:
+
+1. **Write down "done" so a machine could check it.** If you can't name the signal
+   that says it worked, you don't have a loop yet — you have a wish.
+2. **Make the check exist before you tune the behavior.** The test, the validator,
+   the read-back. Fast and cheap, because every pass pays for it.
+3. **Give it the smallest set of sharp tools.** Each returning a result that *teaches*
+   the next step — errors included. Resist the thirty-tool drawer.
+4. **Put the check *inside* the loop, not at the end.** The model should see the
+   result of its last action before choosing the next.
+5. **Set the stop conditions up front.** A budget, an error ceiling, and a human gate
+   on anything irreversible (send, delete, pay, post). A loop with no stop is a bug.
+6. **Instrument, then iterate on the loop — not the prompt.** When something's wrong,
+   ask *which part* failed: context (it couldn't see what it needed), tools (it
+   couldn't act, or got a useless result), verification (it couldn't tell good from
+   bad), or control flow (it looped or stopped wrong). Fix that part. Prompt wording
+   is the last thing you touch, not the first.
+
+A useful gut-check throughout: **would a fixed sequence do?** If the path is known and
+repeatable, write it down as steps and don't pay for autonomy. Reach for an
+open-ended loop only when the path has to be discovered as you go.
+
+## Anti-patterns
+
+- **A loop where a checklist would do.** Autonomy costs time and unpredictability —
+  earn it. Most recurring work is a known sequence, which is exactly why this kit
+  ships rituals as commands.
+- **No verification.** The defining failure. Without a check the loop can't tell it's
+  drifting.
+- **No stop.** Loops that never terminate, or re-summarize the same overflowing
+  context forever. Cap the budget; set an error ceiling.
+- **Stuffing the context "to be safe."** A full window reads *worse*, not better —
+  recall sags in the middle. Curate; push the rest to files (which is why state lives
+  in git here).
+- **Letting a framework own your control flow and your context.** When you can't see
+  the loop or what's in the window, you can't debug either.
+- **No human gate on irreversible actions.** Autonomous send / delete / pay with no
+  checkpoint is how a loop does real damage. Keep a hand on the dial — see the
+  read-only / safe-write / full-write ladder in
+  [`../.claude/rules/crm-usage.md`](../.claude/rules/crm-usage.md).
+
+## How this maps to the kit
+
+You don't have to build any of this from scratch — the kit *is* this shape:
+
+| Loop piece | In this kit |
+|---|---|
+| Context | State in `ops/` (git), the **SessionStart** hook, the **PreCompact** re-inject |
+| Act | Rituals as commands in `.claude/commands/` |
+| Tools | MCP servers you wire in (`.mcp.json`) |
+| Verify | `verify-after-change.sh` + your `verify.sh`; the `checks/` scripts; CRM guardrail 7 ("verify the write landed") |
+| Guardrails | `protect-files.sh`, the pre-commit secret guard |
+| Control flow | The [rules](../.claude/rules/) every run honors |
+| Termination / human gate | The write-authority ladder in [`crm-usage.md`](../.claude/rules/crm-usage.md); a routine that drafts and waits for review |
+| Triggers | [Scheduling](../.claude/scheduling/) — cron, cloud, or a CI backstop |
+
+Designing your loop *is* deciding how these pieces fit for the work in front of you —
+not writing a longer prompt.
+
+## Where this comes from
+
+These ideas are a synthesis of public work on building agents, reimplemented in this
+kit's own words. Worth reading directly:
+
+- Anthropic, *Building Effective Agents* — the "model + tools + loop" framing, and
+  workflow vs. agent.
+- Yao et al. (2022), *ReAct: Synergizing Reasoning and Acting in Language Models* —
+  the original reason → act → observe loop (arXiv:2210.03629).
+- HumanLayer (Dex Horthy), *12-Factor Agents* — own your control flow and your
+  context window; reliable agents are mostly well-engineered software.
+- Manus, *Context Engineering for AI Agents* — shaping the loop's context in
+  production.
+- Andrej Karpathy — the "autonomy slider" / keep-a-human-in-the-loop framing.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -8,7 +8,7 @@ Most people reach for Claude Code as something to *ask* — a faster way to writ
 
 This kit is set up for the whole go-to-market — all four functions across both sides of the bowtie: marketing and sales on the left (the demo pipeline, the qualification / prep / follow-up / outreach / content skills), product and retention on the right (the customer book, the onboarding handoff, account health, the roadmap-signals queue). But the pattern isn't go-to-market-specific: the same shape runs a research practice, a support queue, a founder's week. If you have recurring work and scattered tools, it applies. The mechanics of the four-function motion — the handoffs, the one number, the shared definitions — live in [`operating-model.md`](operating-model.md); this page is about the *environment* they run in.
 
-## Four ideas that make it work
+## Five ideas that make it work
 
 **1. State lives in plain text, in git.** Your playbooks, priorities, and log are markdown files, not rows in someone's database. That sounds modest until you notice the consequences: your operating system has a diff, a history, and a blame view. You can read it, fork it, and fix it in a text editor. And when a long session's context window compacts, nothing important is lost — it's still on disk, and a hook re-injects it.
 
@@ -18,9 +18,11 @@ This kit is set up for the whole go-to-market — all four functions across both
 
 **4. One ritual at a time.** The failure mode is porting your whole working life on day one, then abandoning it. Pick the task you dread most. Make it a command. Run it daily for a week. Then add the next. Compounding comes from small reps, not a heroic weekend.
 
+**5. Close the loop: verify the work.** A ritual that acts but never checks is one you have to babysit. The loop a capable agent runs is *gather context → act → verify → repeat*: read what you need, take a step, check the result against something real — a test that passes, a file that should now exist, a count that should match — and only then move on. Build the check into the ritual, not your memory. Like a guardrail, it can live in a hook (`verify-after-change.sh`) so it runs every time instead of only when you remember. The cheapest verification you'll ever skip is the one that would have caught the silent failure. Why the *loop* — not the prompt — is the thing you design is the argument in [`designing-loops.md`](designing-loops.md).
+
 ## Why this is one system, not four
 
-The kit runs all four go-to-market functions — marketing, sales, product, retention — in one repo on purpose. The buyer already merged them: they research, buy, adopt, and renew as one relationship, and most of a B2B decision now happens before sales is in the room. Drawn honestly the journey isn't a funnel that ends at the sale; it's a bowtie, with the post-sale half (onboarding, adoption, renewal, expansion) usually left with no owner. Running the four as separate systems is what creates the seams the buyer feels. The fix is structural, not cultural, and the four ideas above happen to be it:
+The kit runs all four go-to-market functions — marketing, sales, product, retention — in one repo on purpose. The buyer already merged them: they research, buy, adopt, and renew as one relationship, and most of a B2B decision now happens before sales is in the room. Drawn honestly the journey isn't a funnel that ends at the sale; it's a bowtie, with the post-sale half (onboarding, adoption, renewal, expansion) usually left with no owner. Running the four as separate systems is what creates the seams the buyer feels. The fix is structural, not cultural, and the ideas above happen to be it:
 
 - **One source of truth** → the git repo. Every function reads and writes the same markdown — not four tools with four versions of the truth.
 - **Two feedback loops** → the `marketing-feedback` skill plus a `MARKETING-ACTION` line (sales→marketing), and the `retention-feedback` skill plus a `RETENTION-RISK` line (post-sale→product). What the field and the customer base surface becomes an action in the same system, the same day — version-controlled.


### PR DESCRIPTION
## Summary

Adds the one loop pillar the kit was missing — the **verify** step. The kit already teaches context (state in git) and guardrails (block bad writes); this adds the "did it work?" half, kept generic and in the kit's voice.

**Mechanism**
- `verify-after-change.sh` (PostToolUse Edit|Write) — broken-relative-link check for the changed markdown file, plus runs an optional project verifier at `.claude/scripts/verify.sh`. Advisory only (never blocks), shellcheck-clean, pure bash + `python3` (matches the kit's hook convention).
- `verify.sh.example` — the opt-in template to wire your own check (`make check`, `npm test`, `pytest`, the `checks/` scripts). Fill-the-drawers-yourself, like the other `.example` files.
- `crm-usage.md` **guardrail 7 — "Verify the write landed"** — read back after a write and reconcile. The after-the-write step the six existing guardrails missed.

**Docs**
- `methodology.md`: "Four ideas" → "Five ideas"; adds idea 5, *Close the loop: verify the work* (gather → act → verify → repeat).
- `docs/designing-loops.md` (new): the generic conceptual backbone — the shift from prompting to loop design, the loop anatomy, a six-step build playbook, anti-patterns, how it maps to this kit, and sources (Anthropic *Building Effective Agents*, ReAct, *12-Factor Agents*, Manus, Karpathy).

Deliberately kept minimal — no PII regex, token trackers, or owner-specific routines. The kit's "empty cabinet" promise stays intact.

## Success criteria / Test Plan
- `bash -n` + `shellcheck -S warning` clean on the hook and the example (kit CI runs shellcheck)
- `settings.json` validates with `jq`
- Smoke tests pass: markdown file with a broken link → one advisory warning, exit 0, URLs skipped; a failing project `verify.sh` → its output surfaced, exit 0 (advisory)
- New `designing-loops.md` links resolve; `methodology.md` ↔ `designing-loops.md` cross-links intact

Draft — for review, not merging.

https://claude.ai/code/session_0111BzLbwFxCBRrRmw6uFJCx

---
_Generated by [Claude Code](https://claude.ai/code/session_0111BzLbwFxCBRrRmw6uFJCx)_