### PR TITLE
Add model-choice guidance for scheduled rituals

### DIFF
--- a/.claude/scheduling/README.md
+++ b/.claude/scheduling/README.md
@@ -23,6 +23,22 @@ structure, freshness, broken local links — so a problem with the operating fil
 surfaces even in a week when nothing else ran. A failing scheduled run emails the
 repo owner; that email *is* the signal.
 
+## Choosing a model for a ritual
+
+A schedule also picks the model the ritual runs on (the `--model` flag on a
+local `claude -p` line; the model field on a cloud routine). Two rules of
+thumb keep cost and quality where they belong:
+
+- **Daily rituals** (briefing, check-in, end-of-day) are read-mostly markdown
+  work — your plan's default model is more than enough, and a mid-tier model
+  (Sonnet-class) is fine if you pay per token.
+- **Judgment-heavy runs** (a weekly review on a loaded pipeline, a monthly
+  retention report you act on) earn the strongest model you have access to —
+  schedule those few runs up a tier instead of running everything there.
+
+Model names and tiers change; the split — a cheap default for the daily loop,
+the frontier tier for the few decisions that compound — doesn't.
+
 ## Start here
 
 - **Run it in the cloud:** [`cloud-routines.md`](cloud-routines.md) — the full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Model-choice guidance for scheduled rituals** (`.claude/scheduling/README.md`)
+  — which tier to run a ritual on: a cheap/default model for the daily loop, the
+  frontier tier for the few judgment-heavy runs (weekly review, retention report).
+  Written tier-generic so it survives model releases.
 - **Retention act-skills — the right side gets more than a detector**
   (`.claude/skills/`): `churn-save` (recover a red/amber account — the real risk,
   the re-engagement draft, the renewal-clock timing), `expansion-play` (work a


### PR DESCRIPTION
## Summary

- `.claude/scheduling/README.md` gains a short "Choosing a model for a ritual" section: a cheap/default model for the daily loop (briefing, check-in, end-of-day), the frontier tier for the few judgment-heavy runs (weekly review, retention report).
- Written **tier-generic** — no model names — so the public kit survives model releases without edits (prompted by today's Fable 5 launch, which added a new frontier tier above Opus).
- CHANGELOG entry added under `[Unreleased]`.

## Test Plan

- [ ] README section reads generically (no vendor model IDs, matching the kit's `<placeholder>` convention)
- [ ] Local-link check passes (`.claude/scripts/checks/`)

https://claude.ai/code/session_01FspUoduDyCHzNArf8JBCsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FspUoduDyCHzNArf8JBCsH)_