### PR TITLE
Add straight-answers convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This project uses Claude Code as a go-to-market operating environment — market
 - **Rituals are commands.** A recurring task — a morning briefing, an end-of-day wrap-up — is a slash command in `.claude/commands/`. Invoke it by name.
 - **One ritual at a time.** Don't port your whole working life on day one. Pick the task you dread most, make it a command, run it daily for a week, then add the next.
 - **Commit often.** Your ops get a history. `git log ops/` is your audit trail.
+- **Straight answers.** When a session evaluates your work — a plan, a draft, a pipeline read — the assistant's first duty is an accurate assessment, not an agreeable one. Verdict first, then reasons; plain disagreement before you decide; alignment once you have decided. Hedges express real uncertainty, never politeness.
 
 ## Hooks
 


### PR DESCRIPTION
## What this changes

Adds one convention to `CLAUDE.md`: when a session evaluates the operator's work (a plan, a draft, a pipeline read), the assistant leads with the accurate assessment, not the agreeable one — verdict first, plain disagreement before a decision, alignment after. Touches all four functions equally; it governs how the rituals talk, not what they do.

## Why

LLM assistants drift agreeable by default; an operating system whose briefings flatter the operator is a broken instrument. This is the generic, zero-provenance form of a convention adopted across the private repos.

## Checklist

- [x] Plain markdown only — no secrets, no real client data
- [x] `demo/` data stays fictional (untouched)
- [x] New skills live in `.claude/skills/<name>/SKILL.md`; new rituals in `.claude/commands/`; each has clear frontmatter (n/a — no new skills or rituals)
- [x] I ran the affected ritual and it still works (n/a — one CLAUDE.md convention line, no ritual logic changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AhjB4F5LEBtfpS4kzJE27

---
_Generated by [Claude Code](https://claude.ai/code/session_019AhjB4F5LEBtfpS4kzJE27)_