### PR TITLE
Weekly insights: codify /babysit-prs, fix hygiene drift

### DIFF
--- a/.claude/commands/babysit-prs.md
+++ b/.claude/commands/babysit-prs.md
@@ -1,0 +1,70 @@
+---
+description: Check on this repo's open PRs — CI, review comments, merge conflicts, and any external launch dependency — without re-litigating the same unchanged signal every time.
+---
+
+# Babysit PRs
+
+Codifies a ritual that was already running against this repo's open PRs without a
+checked-in definition — [`Open-PR hygiene`](../../CLAUDE.md#open-pr-hygiene) named the
+backlog problem; this command is the recurring check that watches it. Run on a
+schedule (daily or every few days) or on demand.
+
+## What to check, per open PR
+
+1. **CI status** — the latest check run / workflow run on the PR's head commit. If
+   there are **zero** check runs, say so explicitly — don't imply "green" for a PR
+   CI never actually ran on. (README/CHANGELOG-only diffs can fail to trigger the
+   [CI backstop](../scheduling/README.md) workflow even though its `paths:` filter
+   should catch them — if you see this, name it as a gap to root-cause, not a
+   one-off oddity.)
+2. **Review comments** — any unresolved thread. Unresolved beats "any comment exists."
+3. **Merge conflicts** — `mergeable_state`. Flag `dirty` distinctly from `clean`;
+   a draft sitting on a known external dependency can drift into conflict with
+   `main` while it waits, and that drift compounds the longer it's ignored.
+4. **External launch dependencies** — if the PR body names a condition it's
+   waiting on (another repo's PR merging, a page going live, a manual step called
+   out in another PR's checklist), re-verify that specific condition this run.
+
+## Stale-signal escalation — don't just repeat the same check forever
+
+Track, per PR, how many **consecutive** runs reported the *same* external-dependency
+signal with *no change* (e.g. the same HTTP status on a fetch, the same "still
+DRAFT" on a linked PR). On the **third** consecutive unchanged report:
+
+- Stop re-verifying that signal the same way every run — a fourth identical check
+  adds no information.
+- Escalate **once**, plainly: name that this is now stale and needs a human decision
+  or a different verification method, not another automated recheck.
+- Keep watching CI / review comments / merge conflicts as normal — only the
+  unchanged external signal goes quiet.
+
+This is the fix for the pattern observed on PR #44: the same "`langoptima.com/...`
+returns 403, could be live or could be blocked" line ran unchanged for four straight
+weekly checks before anyone called it stale. One clear escalation beats a fifth
+identical paragraph.
+
+## Output format
+
+One comment per PR, short:
+
+```
+**🤖 Babysit-PRs — <date>**
+
+| Check | Status |
+|---|---|
+| CI | <✅/⚠️/❌ + one-line detail> |
+| Review comments | <✅/⚠️ + detail> |
+| Merge conflicts | <✅ clean / ⚠️ dirty> |
+
+<one line: action taken, or "no action — still ready" / the escalation, if triggered>
+```
+
+Post via the repo's PR-comment tool. Take no other action unless the PR is
+genuinely ready (CI green, no unresolved comments, clean merge state, no
+outstanding dependency) **and** you have explicit standing permission to merge it —
+otherwise this command only reports.
+
+## Depth
+- quick: one PR, the four checks, no escalation tracking.
+- standard: every open PR in the repo, the four checks, stale-signal tracking against the prior comment on each PR.
+- deep: add a cross-PR summary (how many PRs, how long the oldest has been open, which are blocked vs. actionable) and flag any PR open longer than 30 days with no comment in the last 7.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,11 @@ claude-code-growth-os/
 │   │   ├── midday-checkin.md        # 14:00 — action-item sweep + CRM persist
 │   │   ├── end-of-day.md            # 17:30 — daily-log draft + tomorrow's Top 3
 │   │   ├── weekly-review.md         # Friday — pipeline reconcile + feedback loops
-│   │   └── demo-briefing.md         # Pre-meeting briefing for a named prospect/deal
+│   │   ├── demo-briefing.md         # Pre-meeting briefing for a named prospect/deal
+│   │   ├── capture.md               # Ad-hoc — capture-now, triage-later inbox
+│   │   ├── reconcile.md             # Ad-hoc — catch drift across mirrored files
+│   │   ├── retention-report.md      # Monthly — NRR/GRR roll-up, next month's bets
+│   │   └── babysit-prs.md           # Ad-hoc/scheduled — open-PR health + stale-signal escalation
 │   ├── hooks/                       # Guardrails that fire on events
 │   │   ├── session-start.sh         # Surfaces ops/priorities.md + feedback-log signals
 │   │   ├── pre-compact.sh           # Re-injects priorities + latest log before compaction
@@ -130,7 +134,11 @@ Every entry point (session start, each ritual, each cloud routine) uses the spec
 | `/midday-checkin` | 14:00 | Action-item sweep, CRM persist (skips if in a meeting) |
 | `/end-of-day` | 17:30 | Daily-log draft, tomorrow's Top 3, feedback-loop tags |
 | `/weekly-review` | Friday | Pipeline reconcile, feedback-loop close, next week's priority |
+| `/retention-report` | Monthly | NRR/GRR roll-up, churn by reason, next month's bets |
 | `/demo-briefing` | Ad-hoc | Pre-meeting brief for a named prospect or deal |
+| `/capture` | Ad-hoc | Capture-now, triage-later inbox |
+| `/reconcile` | Ad-hoc | Catch drift across mirrored files (mirror-vs-CRM, log-vs-reality) |
+| `/babysit-prs` | Ad-hoc/scheduled | Open-PR health check — CI, review comments, merge conflicts, stale-signal escalation |
 
 ## Hooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/babysit-prs` command** (`.claude/commands/babysit-prs.md`) — codifies an
+  open-PR health check (CI status, unresolved review comments, merge conflicts,
+  external launch dependencies) that had been running against this repo's PRs for
+  weeks with no checked-in definition. Adds a **stale-signal escalation** rule:
+  after three consecutive runs report the same unchanged external-dependency signal
+  (e.g. the same HTTP status on a launch-page check), escalate once as a decision
+  needed rather than repeating the identical check indefinitely — the pattern
+  observed on PR #44, where the same inconclusive signal was re-reported unchanged
+  across four weekly runs.
+
 ### Changed
+
+- **`CLAUDE.md`** — refreshed the *Open-PR hygiene* note (7 open PRs as of
+  2026-07-05 → 4 as of 2026-07-19; #38 has since merged) and wired in
+  `/babysit-prs` and its stale-signal rule. Added a new *Session-analysis routines*
+  section naming that a cloud/web session has no persisted session-transcript
+  history across runs (`~/.claude/projects/` doesn't survive a fresh clone), so a
+  routine like `insights-loop` should fall back to git/PR/CI history as its
+  evidence base and say so, rather than implying it read transcripts that don't
+  exist in this environment.
+- **`AGENTS.md`** — repository map and commands table were missing `/capture`,
+  `/reconcile`, and `/retention-report` (all shipped in earlier releases); added
+  alongside the new `/babysit-prs` entry.
 
 - **`docs/principles-from-the-field.md`** — added three field principles with worked
   go-to-market examples: *a problem going quiet is not the same as a problem being

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,13 @@ Run the rituals on a clock — locally (cron/launchd), in the cloud, or as a CI 
 
 ## Open-PR hygiene
 
-This repo has accumulated open, unmerged PRs from prior sessions (7 open as of 2026-07-05, some dating to early June) — including last month's own `insights-loop` deliverable (#38, the AGENTS.md addition, still unmerged four weeks after it shipped). Before opening a new PR: check `repo:etrebels/claude-code-growth-os is:pr is:open` for existing work on the same topic and continue or merge it rather than adding a near-duplicate. If a recurring skill's own prior PR is still open, that's a signal worth surfacing in its output, not a fresh PR to pile on top.
+This repo has accumulated open, unmerged PRs from prior sessions (7 open as of 2026-07-05; down to 4 as of 2026-07-19 — #38 from that count has since merged). Before opening a new PR: check `repo:etrebels/claude-code-growth-os is:pr is:open` for existing work on the same topic and continue or merge it rather than adding a near-duplicate. If a recurring skill's own prior PR is still open, that's a signal worth surfacing in its output, not a fresh PR to pile on top.
+
+Run [`/babysit-prs`](.claude/commands/babysit-prs.md) to check the open backlog — CI, review comments, merge conflicts, and any external launch dependency a draft PR is waiting on. **Don't re-verify the same unchanged external signal forever**: after three consecutive identical reports (e.g. the same HTTP status on a launch-page check, the same "still DRAFT" on a linked PR), escalate once as a stale signal needing a human call, rather than repeating the same paragraph indefinitely — see the command for the full rule.
+
+## Session-analysis routines (e.g. `insights-loop`)
+
+A remote/cloud session starts from a fresh clone each run; nothing under `~/.claude/projects/` persists across sessions, so "analyze the last N days of Claude Code session transcripts" has no literal data to read beyond the current run. Any routine making that claim should fall back to the evidence that *does* persist — `git log --since`, merged/open PR history, PR review comments, and CI backstop output — and say plainly that it's using that fallback rather than implying it read transcripts it doesn't have.
 
 ## Extending with tools
 


### PR DESCRIPTION
## What this changes

Touches the operating layer (repo-maintenance ritual, not a single one of the four functions): codifies an undocumented recurring PR-health check as `/babysit-prs`, refreshes stale numbers in `CLAUDE.md`'s Open-PR hygiene note, backfills a few missing entries in `AGENTS.md`'s repo map, and documents an environment limitation this run itself hit.

## Why

This is the weekly `insights-loop` run. This cloud session has no persisted `~/.claude/projects/` history across runs, so "analyze the last 7 days of session transcripts" had no literal data — the analysis instead used git log, open/merged PR history, PR review comments, and CI check runs as the evidence base (documented in the new *Session-analysis routines* section so the next run doesn't have to rediscover this).

Three findings, evidenced from that history, drove the changes:

1. **An undocumented ritual is doing real, recurring work.** Dated `Babysit-PRs` comments exist on PRs #44/#48/#49 going back to 2026-06-13 — checking CI, review comments, merge conflicts, and external launch dependencies — but there is no `.claude/commands/babysit-prs.md`, no scheduling entry, and no mention in `AGENTS.md`'s own repository map or commands table. Highest-frequency, highest-impact, most concrete gap found. → Added `.claude/commands/babysit-prs.md`, wired into `AGENTS.md` and `CLAUDE.md`.
2. **The same unchanged external signal gets re-verified indefinitely.** PR #44 has had the identical "`langoptima.com/growth-os-pro` returns 403, could be live or blocked" line re-reported, unchanged, across four consecutive weekly runs (07-12, 07-15, 07-19, and implicitly before) with no escalation beyond "Edwin should check manually" each time. → Added a stale-signal escalation rule to `/babysit-prs`: after three consecutive identical reports, escalate once rather than repeating the check forever.
3. **`CLAUDE.md`'s Open-PR hygiene note had drifted stale.** It still cited "#38 … still unmerged four weeks after it shipped" and "7 open PRs" — #38 merged since (visible in `git log`), and the open count is now 4. → Refreshed both numbers.

Also backfilled `/capture`, `/reconcile`, and `/retention-report` into `AGENTS.md`'s repo map and commands table — all three already ship in `.claude/commands/` but were missing from the map, noticed while editing the adjacent lines.

Fewer than 3 of the candidate findings needed a net-new command; the CI-never-triggers-on-doc-only-drafts gap (flagged by `babysit-prs` itself on #48/#49, 07-11, never fixed since) is folded into `/babysit-prs`'s CI-check step rather than a separate change, since it's the same command that surfaces it.

## Checklist

- [x] Plain markdown only — no secrets, no real client data
- [x] `demo/` data stays fictional (untouched)
- [x] New ritual lives in `.claude/commands/babysit-prs.md` with clear frontmatter
- [x] Ran `.claude/scripts/checks/growth-os-checks.sh` — 0 hard failures, links resolve (2 pre-existing unrelated soft findings on `ops/daily-log.md` / `ops/feedback-log.md` freshness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Naq5ZSac7CCU9PCsNJonac

---
_Generated by [Claude Code](https://claude.ai/code/session_01Naq5ZSac7CCU9PCsNJonac)_