### PR TITLE
docs: add call-conduct block to meeting-prep

### DIFF
--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -38,6 +38,27 @@ Load **3–5** calibrated questions for the meeting. A reusable set:
 
 **Replace on sight:** "Why are you still using X?" → *"What's kept X in place?"* · "Do you have a process for X?" → *"How do you handle X today?"* · "Is that a problem?" → *"What does that cost you?"* · "Would you agree that…?" → delete it.
 
+## Call conduct — write down what the room used to enforce
+
+In a physical room, attention is enforced by cues nobody has to state: everyone can
+see who is looking at their phone, who left, who stopped listening. Remove the room
+and every one of those cues disappears — so attention degrades silently while the
+call grid looks exactly the same. A remote meeting with no stated protocol is not a
+neutral meeting; its norms default to whatever the least-engaged participant does.
+
+The fix is not exhortation ("please engage") — it is writing down the specific
+behaviors the room used to enforce for free, so the norm is explicit and correctable.
+
+For any call with **4+ participants or a decision on the agenda**, put one line at the
+top of the agenda itself:
+
+> *Cameras on · one speaker at a time · side questions to the thread, not the chat ·
+> decision owner: `<name>`.*
+
+If a call is repeatedly held without it, the meeting owner cuts the invite list rather
+than adding more reminders — an unengaged attendee is a scoping problem, not a
+discipline problem.
+
 ## Depth
 - quick: the goal + one label + three calibrated questions.
 - standard: the full brief above, with the label + 3–5 calibrated questions and a summary-to-confirm.


### PR DESCRIPTION
## What this changes

Adds a **Call conduct** section to the `meeting-prep` skill — a one-line protocol that goes on the agenda for any call with 4+ participants or a decision on it. Touches sales and product (any function that runs decision calls).

## Why

In a physical room, attention is enforced by cues nobody has to write down: everyone can see who is on their phone, who left, who stopped listening. Remove the room and every one of those cues disappears, so attention degrades silently while the call grid looks exactly the same. A remote meeting with no stated protocol is not a neutral meeting — its norms default to whatever the least-engaged participant does.

The fix is not exhortation ("please engage"), which is what teams reach for first and which does nothing. It is writing down the specific behaviors the room used to enforce for free, so the norm becomes explicit and correctable. The section also makes cutting the invite list the response to repeated drift, on the grounds that an unengaged attendee is a scoping problem rather than a discipline problem.

## Checklist

- [x] Plain markdown only — no secrets, no real client data
- [x] `demo/` data stays fictional
- [x] New skills live in `.claude/skills/<name>/SKILL.md`; new rituals in `.claude/commands/`; each has clear frontmatter
- [x] I ran the affected ritual (`meeting-prep`) and it still works — the skill reads end to end with the new section between the questions guidance and the `## Depth` block; frontmatter unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJdFdsGxSPrr6tiZiF5fQV)_