### PR TITLE
Make the repo installable as a plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "growth-os",
+  "description": "Go-to-market skills for Claude Code — run marketing, sales, product and retention as one motion instead of four silos.",
+  "owner": {
+    "name": "Edwin Trebels",
+    "email": "edwin.trebels@langoptima.com",
+    "url": "https://github.com/etrebels"
+  },
+  "plugins": [
+    {
+      "name": "growth-os",
+      "source": ".",
+      "description": "Nineteen go-to-market skills spanning marketing, sales, product and retention — lead qualification, meeting prep, follow-ups, outreach, account health, churn saves, expansion signals, and the two cross-function feedback loops. Install for the skills; clone the repo for the full ritual system.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "homepage": "https://github.com/etrebels/claude-code-growth-os",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "growth-os",
+  "displayName": "Claude Code Growth OS",
+  "description": "Nineteen go-to-market skills spanning marketing, sales, product and retention — lead qualification, meeting prep, follow-ups, outreach, account health, churn saves, expansion signals, and the two cross-function feedback loops. Install for the skills; clone the repo for the full ritual system.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Edwin Trebels",
+    "email": "edwin.trebels@langoptima.com"
+  },
+  "homepage": "https://github.com/etrebels/claude-code-growth-os",
+  "repository": "https://github.com/etrebels/claude-code-growth-os",
+  "license": "MIT",
+  "keywords": [
+    "sales",
+    "marketing",
+    "go-to-market",
+    "crm",
+    "pipeline",
+    "retention",
+    "customer-success",
+    "revenue",
+    "growth"
+  ],
+  "skills": [
+    "./.claude/skills/account-health",
+    "./.claude/skills/calendar-followup",
+    "./.claude/skills/churn-save",
+    "./.claude/skills/cold-outreach",
+    "./.claude/skills/content-repurpose",
+    "./.claude/skills/event-to-pipeline",
+    "./.claude/skills/expansion-signal",
+    "./.claude/skills/follow-up",
+    "./.claude/skills/inbox-digest",
+    "./.claude/skills/lead-qualify",
+    "./.claude/skills/marketing-feedback",
+    "./.claude/skills/meeting-prep",
+    "./.claude/skills/onboarding-handoff",
+    "./.claude/skills/product-signal",
+    "./.claude/skills/qbr-prep",
+    "./.claude/skills/retention-feedback",
+    "./.claude/skills/status-update",
+    "./.claude/skills/support-signal",
+    "./.claude/skills/triage"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ This repo is the scaffolding: opinionated hooks, daily rituals, a set of go-to-m
 
 **Why one repo for the whole motion?** The buyer merged it — they research, buy, adopt, and renew as one relationship, and most of a B2B decision happens before sales is even in the room. Running marketing, sales, product, and retention as four separate systems is what creates the seams the buyer feels — and leaves the most valuable half, what happens *after* the sale, with no owner. This kit keeps all four in one place: one source of truth (the repo), two feedback loops (a `MARKETING-ACTION` line for sales→marketing, a `RETENTION-RISK` line for post-sale→product), shared definitions. The one-page argument, with sources, is in [`docs/why-align.md`](docs/why-align.md).
 
+## Install just the skills (no clone)
+
+Want the go-to-market skills without adopting the whole repo? This repo is also a plugin marketplace:
+
+```
+/plugin marketplace add etrebels/claude-code-growth-os
+/plugin install growth-os@growth-os
+```
+
+That gives you the nineteen skills — lead qualification, meeting prep, follow-ups, outreach, account health, churn saves, expansion signals, the two feedback loops — usable in any project.
+
+**The plugin ships skills only, deliberately.** The daily rituals (`/morning-briefing`, `/end-of-day`, `/weekly-review`) read and write the `ops/` state files, so they only make sense inside the repo. Clone it for those; install the plugin if you just want the skills.
+
 ## See it run in 30 seconds
 
 ![Claude Code Growth OS — the /demo-briefing morning ritual running on fictional demo data](docs/assets/demo.gif)


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so the kit installs without a clone:

```
/plugin marketplace add etrebels/claude-code-growth-os
/plugin install growth-os@growth-os
```

`claude plugin validate .` passes with no warnings, and all 19 listed skill paths were verified to resolve to a real `SKILL.md`.

## The one design decision

**The plugin ships skills only.** The daily rituals (`/morning-briefing`, `/end-of-day`, `/weekly-review`, `/retention-report`) read and write the `ops/` state files — installed as a plugin into an unrelated project they would fire against a directory structure that isn't there, and fail confusingly on first use.

The 19 skills, by contrast, reference `ops/` softly and already degrade gracefully ("point me at one in `ops/` or paste a recap", "edit them to your own ICP in `ops/icp.md` if you keep one"), so they work standalone.

The README now states the split explicitly: install the plugin for the skills, clone the repo for the ritual system.

`example-skill` is excluded from the manifest — it's a template for contributors, not a skill users should see in their list.

## Why this matters commercially

This is the free distribution rung. Plugin marketplaces put the kit in front of people at the moment they're making a build decision, at near-zero acquisition cost — which is the position `plugin-distribution-strategy.md` argues for. It costs nothing and carries no licence dependency, so it can ship ahead of anything paid.

## Test plan

- `claude plugin validate .` → passes clean (was one warning about `category` in `plugin.json`; removed).
- Both manifests parse as valid JSON.
- All 19 skill paths verified to contain `SKILL.md`.
- Manual check still needed: `/plugin marketplace add` against the pushed branch once merged, then confirm the skills appear and one fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_018yMN7cRF4csP4i97ajj5Rh)_