### PR TITLE
end-of-day: re-route real blockers, don't just park them

### DIFF
--- a/.claude/commands/end-of-day.md
+++ b/.claude/commands/end-of-day.md
@@ -11,7 +11,7 @@ Close out the day:
 1. Ask me what got done today (or infer it from `git log` since this morning) — across both sides of the bowtie: deals worked *and* post-sale touches (onboarding steps, adoption nudges, renewal/expansion moves, signals routed to product).
 2. Append a dated entry to `ops/daily-log.md` (newest at the top): shipped, slipped, one thing learned. Log post-sale work alongside deals — a renewal call or an adoption fix counts the same as a deal advanced.
 3. **Persist & reconcile the CRM.** Write the day's stage/score/note changes back per [`.claude/rules/crm-usage.md`](../rules/crm-usage.md), then reconcile the mirror — rewrite `ops/pipeline.md` from the CRM so tomorrow opens consistent. Skip if no CRM is connected.
-4. **Lion check.** If a task keeps rolling forward behind a citable obstacle, name it plainly — a thing repeatedly deferred behind the same reason is usually avoidance, not a blocker. Decide: do it tomorrow, or drop it.
+4. **Lion check.** If a task keeps rolling forward behind a citable obstacle, name it plainly, then sort it. A thing repeatedly deferred behind the same reason is usually avoidance, not a blocker — decide: do it tomorrow, or drop it. But if the obstacle is a *real* blocker, don't just park it behind the block either — name at least one route around it: a smaller version you can ship now, a different path to the same outcome, or the specific person who can unblock it. A blocked item leaves the close with a next action, never just a later date.
 5. Draft tomorrow's top three into `ops/priorities.md`.
 6. Confirm what you wrote — and log every CRM write (`object · field · old → new`). Keep it tight.
 


### PR DESCRIPTION
## What this changes

Sharpens the `/end-of-day` **Lion check** (step 4) so a genuinely blocked task gets re-routed instead of silently parked. Touches the **retention / operations** ritual layer — the daily close.

## Why

Step 4 already caught avoidance-disguised-as-blocker ("do it tomorrow, or drop it"), but had no move for a *real* blocker — which would quietly carry forward untouched behind the same reason. Now a real blocker leaves the close with a **next action**: a smaller shippable version, an alternate path to the same outcome, or the specific person who can unblock it — never just a later date. (Distilled from a Resourcefulness principle; folded into the existing step rather than added as a parallel note, so the blocked-task concern keeps a single home.)

## Checklist

- [x] Plain markdown only — no secrets, no real client data
- [x] `demo/` data stays fictional (untouched)
- [x] New skills / rituals — n/a; this edits an existing ritual, frontmatter unchanged
- [x] Reviewed the rendered step in place — prose-only edit, no executable code path to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSQZn1aEifDigvsKNQaPgH)_