### PR TITLE
Add plain-language-first to the conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This project uses Claude Code as a go-to-market operating environment — market
 - **One ritual at a time.** Don't port your whole working life on day one. Pick the task you dread most, make it a command, run it daily for a week, then add the next.
 - **Commit often.** Your ops get a history. `git log ops/` is your audit trail.
 - **Straight answers.** When a session evaluates your work — a plan, a draft, a pipeline read — the assistant's first duty is an accurate assessment, not an agreeable one. Verdict first, then reasons; plain disagreement before you decide; alignment once you have decided. Hedges express real uncertainty, never politeness.
+- **Plain language first.** The plain statement carries the meaning; the specialist term is a label attached after it, never the sentence itself. This applies to internal output too — headings in your playbooks, PR titles, commit messages, the summary a ritual hands back — not just customer-facing copy. Avoid the audience exemption ("they're technical, they'll know it"): that is what you grant yourself at the moment you most want the jargon. The test is mechanical — delete the specialist word and see whether the sentence still stands. If it collapses, the word was doing the sentence's job. A position nobody can restate from memory is not governing anything.
 
 ## Hooks
 


### PR DESCRIPTION
## Summary

One convention added to `CLAUDE.md`: **the plain statement carries the meaning; the specialist term is a label attached after it, never the sentence itself.**

Two things make it worth adding rather than assuming:

- **It covers internal output.** Playbook headings, PR titles, commit messages, the summary a ritual hands back — not only customer-facing copy. That is where this kind of wording actually goes wrong, because customer copy already gets read by someone who would notice.
- **It has no audience exemption.** "They're technical, they'll know it" is the clause a writer grants themselves at the exact moment they most want the jargon, so it never holds. The test is mechanical instead: **delete the specialist word and see whether the sentence still stands.** If it collapses, the word was doing the sentence's job.

Kept generic and provenance-free, per this kit's bar — no internal rule paths, no reference to how it came up.

## Why it earns a line in a short conventions list

A heading nobody can restate from memory is not governing anything. That is the same argument behind keeping the conventions list short in the first place, so this belongs there rather than in a longer doc nobody opens.

## Test plan

- [x] Single-line addition to the `## Conventions` list; no other file touched
- [x] No internal paths, names, or provenance leaked into the public kit
- [x] Reads as guidance an adopter can apply on day one without any LangOptima context

---
_Generated by [Claude Code](https://claude.ai/code/session_013GiwqhdJGtfwZhvx3fkgod)_